### PR TITLE
dmidecode: Get OEM vendor from System Information (DMI type 1)

### DIFF
--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -5268,7 +5268,7 @@ static void dmi_table(Log_t *logp, int type, u32 base, u16 len, u16 num, u16 ver
                  */
 
                 /* assign vendor for vendor-specific decodes later */
-                if(h.type == 0 && h.length >= 5) {
+                if(h.type == 1 && h.length >= 5) {
                         dmi_set_vendor(&h);
                 }
 


### PR DESCRIPTION
DMI type 0 is the BIOS information, it doesn't tell us about the
system vendor. DMI type 1 does that. It made no difference so far
because the only vendor with support for OEM-type decoding was HP and
they make their own BIOS, but it will matter as soon as we add support
for more vendors.

Should fix this crash reported by David Pinkerton:

```
Program received signal SIGSEGV, Segmentation fault.
dmi_set_vendor (s=0x0) at src/dmioem.c:45
45              if(strcmp(s, "HP") == 0)
```

This is a backport of
https://github.com/mirror/dmidecode/commit/6e3a3f3cd36f633a56437b42e40d6769ad8acfe7
