### PR TITLE
python-dmidecode doesn't trim whitespace from some fields.

### DIFF
--- a/src/dmixml.c
+++ b/src/dmixml.c
@@ -198,8 +198,19 @@ xmlNode *dmixml_AddDMIstring(xmlNode *node, const char *tagname, const struct dm
 		res = xmlNewChild(node, NULL, tagname_s, NULL);
                 dmixml_AddAttribute(res, "badindex", "1");
         } else {
+                xmlChar *ret = NULL;
+                xmlChar *ptr = NULL;
                 xmlChar *val_s =  xmlCharStrdup(dmistr);
-                res = xmlNewTextChild(node, NULL, tagname_s, val_s);
+                // Right trim the string
+                ret = val_s;
+                ptr = ret + xmlStrlen(ret) - 1;
+                while( (ptr >= ret) && (*ptr == ' ') ) {
+                    *ptr = 0;
+                    ptr--;
+                }
+                // Do not add any contents if the string contents is "(null)"
+                res = xmlNewTextChild(node, NULL, tagname_s,
+                    (xmlStrcmp(val_s, (xmlChar *) "(null)") == 0 ? NULL : val_s));
                 free(val_s);
         }
         return res;


### PR DESCRIPTION
The issue is introduced in commit 10a2d8bd43934966dd842fd8f401f0d679d0d66a.
Do not add any contents if the string contents(val_s) is "(null)".

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>