### PR TITLE
codecov: allow to pass the codecov/patch coverage checking.

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -9,9 +9,10 @@ coverage:
 
   status:
     project: yes
-    patch: yes
+    patch:
       default:
-        target: 0%
+        target: auto
+        threshold: 100%
     changes: no
 
 parsers:


### PR DESCRIPTION
The codecov coverage about the patch is very inconsistent, let's
pass the checking no matter what the coverage is.

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>