### PR TITLE
Fix memory Type Detail map size

### DIFF
--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -2905,9 +2905,9 @@ void dmi_memory_device_type_detail(xmlNode *node, u16 code)
         dmixml_AddAttribute(data_n, "dmispec", "7.18.3");
         dmixml_AddAttribute(data_n, "flags", "0x%04x", code);
 
-        if((code & 0x1FFE) != 0) {
+        if((code & 0xFFFE) != 0) {
                 int i;
-                for(i = 1; i <= 14; i++) {
+                for(i = 1; i <= 15; i++) {
                         if(code & (1 << i)) {
                                 xmlNode *td_n = dmixml_AddTextChild(data_n, "flag", "%s", detail[i - 1]);
                                 assert( td_n != NULL );

--- a/src/pymap.xml
+++ b/src/pymap.xml
@@ -440,7 +440,7 @@
               valuetype="string" value="concat(TotalWidth, ' ', TotalWidth/@unit)"/>
           <Map keytype="constant" key="AssetTag" valuetype="string" value="AssetTag"/>
           <Map keytype="constant" key="Type Detail" valuetype="list:string" value="TypeDetails/flag"
-              fixedsize="12" index_attr="index"/>
+              fixedsize="15" index_attr="index"/>
           <Map keytype="constant" key="Array Handle" valuetype="string" value="@ArrayHandle"/>
           <Map keytype="constant" key="Form Factor" valuetype="string" value="FormFactor"/>
           <Map keytype="constant" key="Size"


### PR DESCRIPTION
Fix memory Type Detail map size

Bit mapped type descriptions array size must be kept coerent with bit mask,
for index and array size in xml map otherwise nasty errors could arise.
Problem discovered on a machine having
<TypeDetails dmispec="7.18.3" flags="0x2080">

Signed-off-by: Marco Filippi <filippi@dei.unipd.it>