### PR TITLE
Enable alignment workaround for 32-bit ARM arch

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -53,7 +53,7 @@
 #endif
 
 /* Use memory alignment workaround or not */
-#ifdef __ia64__
+#if defined(__ia64__) || defined(__arm__)
 #define ALIGNMENT_WORKAROUND
 #endif
 


### PR DESCRIPTION
Or unit test fails with:

     * Testing type 12...PASS
     * Testing type 19...make[1]: *** [Makefile:4: test] Bus error
  make[1]: Leaving directory '/usr/src/RPM/BUILD/python-modules-dmidecode-3.12.2/unit-tests'
  make: *** [Makefile:104: unit] Error 2

Signed-off-by: Vitaly Chikunov <vt@altlinux.org>