### PR TITLE
Fix RESOURCE_LEAK errors and some obvious errors found by covscan 

### DIFF
--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -222,7 +222,7 @@ void dmi_dump(xmlNode *node, struct dmi_header * h)
         for(row = 0; row < ((h->length - 1) >> 4) + 1; row++) {
                 memset(tmp_s, 0, (h->length * 2) + 2);
 
-                for(i = 0; i < (16 && i < h->length - (row << 4)); i++) {
+                for(i = 0; i < 16 && (i < h->length - (row << 4)); i++) {
                         snprintf(tmp_s + strlen(tmp_s), (h->length * 2)-strlen(tmp_s),
                                  "0x%02x", (h->data)[(row << 4) + i]);
                 }

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -1372,7 +1372,7 @@ void dmi_processor_upgrade(xmlNode *node, u8 code)
                 "Socket LGA1156",
                 "Socket LGA1567",
                 "Socket PGA988A",
-                "Socket BGA1288"        /* 0x20 */
+                "Socket BGA1288",        /* 0x20 */
                 "Socket rPGA988B",
                 "Socket BGA1023",
                 "Socket BGA1224",
@@ -1840,7 +1840,7 @@ void dmi_cache_associativity(xmlNode *node, u8 code)
                 "24-way Set-associative",
                 "32-way Set-associative",
                 "48-way Set-associative",
-                "64-way Set-associative"        /* 0x0D */
+                "64-way Set-associative",        /* 0x0D */
                 "20-way Set-associative"        /* 0x0E */
         };
         xmlNode *data_n = xmlNewChild(node, NULL, (xmlChar *) "Associativity", NULL);
@@ -2865,7 +2865,7 @@ void dmi_memory_device_type(xmlNode *node, u8 code)
                 "Reserved",
                 "Reserved",
                 "Reserved",
-                "DDR3"
+                "DDR3",
                 "FBD2"          /* 0x19 */
         };
         xmlNode *data_n = xmlNewChild(node, NULL, (xmlChar *) "Type", NULL);

--- a/src/dmierror.c
+++ b/src/dmierror.c
@@ -52,7 +52,6 @@ void _pyReturnError(void *exception, const char *fname, int line, const char *fm
 
         va_start(ap, fmt);
         buf = (char *) malloc(4098);
-        memset(buf, 0, 4098);
 
         if( buf == NULL ) {
                 // Backup routine if we can't get the needed memory
@@ -64,6 +63,7 @@ void _pyReturnError(void *exception, const char *fname, int line, const char *fm
                 return;
         }
 
+        memset(buf, 0, 4098);
         // Set the error state and message
         snprintf(buf, 4096, "[%s:%i] %s", fname, line, fmt);
         PyErr_Format(exception, buf, ap);

--- a/src/dmilog.c
+++ b/src/dmilog.c
@@ -47,6 +47,7 @@ Log_t * log_init()
 	ret = (Log_t *) calloc(1, sizeof(Log_t)+2);
 	if( !ret ) {
 		fprintf(stderr, "** ERROR **  Could not allocate memory for log data\n");
+        return ret;
 	}
 	ret->level = -1; // Initialised - chain header pointer always have -1.
 	return ret;

--- a/src/util.c
+++ b/src/util.c
@@ -112,7 +112,7 @@ void sigill_handler(int ignore_this) {
 void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
 {
         void *p;
-        int fd;
+        int fd = -1;
 
 #ifdef USE_MMAP
         size_t mmoffset;
@@ -182,10 +182,11 @@ void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
         }
 #endif /* USE_MMAP */
 
-        if(close(fd) == -1)
-                perror(devmem);
-
  exit:
+        if (fd >= 0) {
+            if(close(fd) == -1)
+                perror(devmem);
+        }
         signal(SIGILL, SIG_DFL);
         sigill_logobj = NULL;
         return p;

--- a/src/xmlpythonizer.c
+++ b/src/xmlpythonizer.c
@@ -854,6 +854,9 @@ PyObject *_deep_pythonize(Log_t *logp, PyObject *retdata,
                         value = PyBytes_FromString(map_p->value);
                         PyADD_DICT_VALUE(retdata, key, value);
                 } else {
+                        xmlXPathFreeContext(xpctx);
+                        xmlFreeDoc(xpdoc);
+                        free(key);
                         PyReturnError(PyExc_ValueError, "Could not get key value: %s [%i] (Defining key: %s)",
                                       map_p->rootpath, elmtid, map_p->key);
                 }
@@ -918,6 +921,10 @@ PyObject *_deep_pythonize(Log_t *logp, PyObject *retdata,
                                 PyADD_DICT_VALUE(retdata, key, value);
                                 xmlXPathFreeObject(xpo);
                         } else {
+                                xmlXPathFreeObject(xpo);
+                                xmlXPathFreeContext(xpctx);
+                                xmlFreeDoc(xpdoc);
+                                free(key);
                                 PyReturnError(PyExc_ValueError, "Could not get key value: "
                                               "%s [%i] (Defining key: %s)",
                                               map_p->rootpath, elmtid, map_p->key);
@@ -931,6 +938,9 @@ PyObject *_deep_pythonize(Log_t *logp, PyObject *retdata,
                         break;
                 }
                 if( _get_key_value(logp, key, 256, map_p, xpctx, 0) == NULL ) {
+                        xmlXPathFreeContext(xpctx);
+                        xmlFreeDoc(xpdoc);
+                        free(key);
                         PyReturnError(PyExc_ValueError,
                                       "Could not get key value: %s [%i] (Defining key: %s)",
                                       map_p->rootpath, elmtid, map_p->key);
@@ -945,6 +955,9 @@ PyObject *_deep_pythonize(Log_t *logp, PyObject *retdata,
                         break;
                 }
                 if( _get_key_value(logp, key, 256, map_p, xpctx, 0) == NULL ) {
+                        xmlXPathFreeContext(xpctx);
+                        xmlFreeDoc(xpdoc);
+                        free(key);
                         PyReturnError(PyExc_ValueError,
                                       "Could not get key value: %s [%i] (Defining key: %s)",
                                       map_p->rootpath, elmtid, map_p->key);
@@ -956,6 +969,9 @@ PyObject *_deep_pythonize(Log_t *logp, PyObject *retdata,
                         if( xpo != NULL ) {
                                 xmlXPathFreeObject(xpo);
                         }
+                        xmlXPathFreeContext(xpctx);
+                        xmlFreeDoc(xpdoc);
+                        free(key);
                         PyReturnError(PyExc_ValueError,
                                       "Could not get key value: %s [%i] (Defining key: %s)",
                                       map_p->rootpath, elmtid, map_p->key);
@@ -991,6 +1007,10 @@ PyObject *_deep_pythonize(Log_t *logp, PyObject *retdata,
                                         PyList_Append(value, dataset);
                                 }
                         } else {
+                                xmlXPathFreeObject(xpo);
+                                xmlXPathFreeContext(xpctx);
+                                xmlFreeDoc(xpdoc);
+                                free(key);
                                 // If NULL, something is wrong - exception is already set.
                                 return NULL;
                         }
@@ -1047,6 +1067,8 @@ PyObject *pythonizeXMLnode(Log_t *logp, ptzMAP *in_map, xmlNode *data_n) {
 
                         xpctx = xmlXPathNewContext(xpdoc);
                         if( xpctx == NULL ) {
+                                xmlFreeDoc(xpdoc);
+                                free(key);
                                 PyReturnError(PyExc_MemoryError, "Could not setup new XPath context");
                         }
                         xpctx->node = data_n;
@@ -1062,6 +1084,10 @@ PyObject *pythonizeXMLnode(Log_t *logp, ptzMAP *in_map, xmlNode *data_n) {
                                                 if( res == NULL ) {
                                                         // Exit if we get NULL - something is wrong
                                                         //and exception is set
+                                                        xmlXPathFreeObject(xpo);
+                                                        xmlXPathFreeContext(xpctx);
+                                                        xmlFreeDoc(xpdoc);
+                                                        free(key);
                                                         return NULL;
                                                 }
                                         }
@@ -1084,6 +1110,7 @@ PyObject *pythonizeXMLnode(Log_t *logp, ptzMAP *in_map, xmlNode *data_n) {
                         if( res == NULL ) {
                                 // Exit if we get NULL - something is wrong
                                 //and exception is set
+                                free(key);
                                 return NULL;
                         }
                 }


### PR DESCRIPTION
This PR fixes the following RESOURCE_LEAK errors and some obvious errors found by covscan,
```
List of Defects
Error: RESOURCE_LEAK (CWE-772): [#def1]
python-dmidecode-3.12.2/src/dmidecodemodule.c:274: alloc_fn: Storage is returned from allocation function "xmlNewNode".
python-dmidecode-3.12.2/src/dmidecodemodule.c:274: var_assign: Assigning: "dmixml_n" = storage returned from "xmlNewNode(NULL, (xmlChar *)"dmidecode")".
python-dmidecode-3.12.2/src/dmidecodemodule.c:284: leaked_storage: Variable "dmixml_n" going out of scope leaks the storage it points to.
#  282|           if( (group_n = load_mappingxml(opt)) == NULL) {
#  283|                   // Exception already set by calling function
#  284|->                 return NULL;
#  285|           }
#  286|   

Error: RESOURCE_LEAK (CWE-772): [#def2]
python-dmidecode-3.12.2/src/dmidecodemodule.c:321: alloc_fn: Storage is returned from allocation function "log_retrieve".
python-dmidecode-3.12.2/src/dmidecodemodule.c:321: var_assign: Assigning: "err" = storage returned from "log_retrieve(opt->logdata, 3)".
python-dmidecode-3.12.2/src/dmidecodemodule.c:323: leaked_storage: Variable "err" going out of scope leaks the storage it points to.
#  321|                           char *err = log_retrieve(opt->logdata, LOG_ERR);
#  322|                           log_clear_partial(opt->logdata, LOG_ERR, 0);
#  323|->                         PyReturnError(PyExc_RuntimeError, "Invalid type id '%s' -- %s", typeid, err);
#  324|                   }
#  325|   

Error: RESOURCE_LEAK (CWE-772): [#def3]
python-dmidecode-3.12.2/src/dmidecodemodule.c:388: alloc_fn: Storage is returned from allocation function "xmlNewNode".
python-dmidecode-3.12.2/src/dmidecodemodule.c:388: var_assign: Assigning: "dmixml_n" = storage returned from "xmlNewNode(NULL, (xmlChar *)"dmidecode")".
python-dmidecode-3.12.2/src/dmidecodemodule.c:397: leaked_storage: Variable "dmixml_n" going out of scope leaks the storage it points to.
#  395|           // Fetch the Mapping XML file
#  396|           if( load_mappingxml(opt) == NULL) {
#  397|->                 return NULL;
#  398|           }
#  399|   

Error: RESOURCE_LEAK (CWE-772): [#def4]
python-dmidecode-3.12.2/src/dmidecodemodule.c:823: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/dmidecodemodule.c:823: var_assign: Assigning: "opt" = storage returned from "malloc(58UL)".
python-dmidecode-3.12.2/src/dmidecodemodule.c:824: noescape: Resource "opt" is not freed or pointed-to in "memset". [Note: The source code implementation of the function has been overridden by a builtin model.]
python-dmidecode-3.12.2/src/dmidecodemodule.c:825: noescape: Resource "opt" is not freed or pointed-to in "init".
python-dmidecode-3.12.2/src/dmidecodemodule.c:833: leaked_storage: Variable "opt" going out of scope leaks the storage it points to.
#  831|   #endif
#  832|           if (module == NULL)
#  833|->                 MODINITERROR;
#  834|   
#  835|           version = PYTEXT_FROMSTRING(VERSION);

Error: RESOURCE_LEAK (CWE-772): [#def5]
python-dmidecode-3.12.2/src/util.c:123: open_fn: Returning handle opened by "open". [Note: The source code implementation of the function has been overridden by a user model.]
python-dmidecode-3.12.2/src/util.c:123: var_assign: Assigning: "fd" = handle returned from "open(devmem, 0)".
python-dmidecode-3.12.2/src/util.c:147: noescape: Resource "fd" is not freed or pointed-to in "mmap".
python-dmidecode-3.12.2/src/util.c:191: leaked_handle: Handle variable "fd" going out of scope leaks the handle.
#  189|           signal(SIGILL, SIG_DFL);
#  190|           sigill_logobj = NULL;
#  191|->         return p;
#  192|   }
#  193|   

Error: RESOURCE_LEAK (CWE-772): [#def6]
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:853: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:857: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
#  855|                           PyADD_DICT_VALUE(retdata, key, value);
#  856|                   } else {
#  857|->                         PyReturnError(PyExc_ValueError, "Could not get key value: %s [%i] (Defining key: %s)",
#  858|                                         map_p->rootpath, elmtid, map_p->key);
#  859|                   }

Error: RESOURCE_LEAK (CWE-772): [#def7]
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:879: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:921: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
#  919|                                   xmlXPathFreeObject(xpo);
#  920|                           } else {
#  921|->                                 PyReturnError(PyExc_ValueError, "Could not get key value: "
#  922|                                                 "%s [%i] (Defining key: %s)",
#  923|                                                 map_p->rootpath, elmtid, map_p->key);

Error: RESOURCE_LEAK (CWE-772): [#def8]
python-dmidecode-3.12.2/src/xmlpythonizer.c:877: alloc_fn: Storage is returned from allocation function "_get_xpath_values".
python-dmidecode-3.12.2/src/xmlpythonizer.c:877: var_assign: Assigning: "xpo" = storage returned from "_get_xpath_values(xpctx, map_p->value)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:921: leaked_storage: Variable "xpo" going out of scope leaks the storage it points to.
#  919|                                   xmlXPathFreeObject(xpo);
#  920|                           } else {
#  921|->                                 PyReturnError(PyExc_ValueError, "Could not get key value: "
#  922|                                                 "%s [%i] (Defining key: %s)",
#  923|                                                 map_p->rootpath, elmtid, map_p->key);

Error: RESOURCE_LEAK (CWE-772): [#def9]
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:933: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:934: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
#  932|                   }
#  933|                   if( _get_key_value(logp, key, 256, map_p, xpctx, 0) == NULL ) {
#  934|->                         PyReturnError(PyExc_ValueError,
#  935|                                         "Could not get key value: %s [%i] (Defining key: %s)",
#  936|                                         map_p->rootpath, elmtid, map_p->key);

Error: RESOURCE_LEAK (CWE-772): [#def10]
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:947: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:948: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
#  946|                   }
#  947|                   if( _get_key_value(logp, key, 256, map_p, xpctx, 0) == NULL ) {
#  948|->                         PyReturnError(PyExc_ValueError,
#  949|                                         "Could not get key value: %s [%i] (Defining key: %s)",
#  950|                                         map_p->rootpath, elmtid, map_p->key);

Error: RESOURCE_LEAK (CWE-772): [#def11]
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:947: identity_transfer: Passing "key" as argument 2 to function "_get_key_value", which returns that argument.
python-dmidecode-3.12.2/src/xmlpythonizer.c:947: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:959: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
#  957|                                   xmlXPathFreeObject(xpo);
#  958|                           }
#  959|->                         PyReturnError(PyExc_ValueError,
#  960|                                         "Could not get key value: %s [%i] (Defining key: %s)",
#  961|                                         map_p->rootpath, elmtid, map_p->key);

Error: RESOURCE_LEAK (CWE-772): [#def12]
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:847: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:947: identity_transfer: Passing "key" as argument 2 to function "_get_key_value", which returns that argument.
python-dmidecode-3.12.2/src/xmlpythonizer.c:947: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:995: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
#  993|                           } else {
#  994|                                   // If NULL, something is wrong - exception is already set.
#  995|->                                 return NULL;
#  996|                           }
#  997|                   }

Error: RESOURCE_LEAK (CWE-772): [#def13]
python-dmidecode-3.12.2/src/xmlpythonizer.c:954: alloc_fn: Storage is returned from allocation function "_get_xpath_values".
python-dmidecode-3.12.2/src/xmlpythonizer.c:954: var_assign: Assigning: "xpo" = storage returned from "_get_xpath_values(xpctx, map_p->value)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:995: leaked_storage: Variable "xpo" going out of scope leaks the storage it points to.
#  993|                           } else {
#  994|                                   // If NULL, something is wrong - exception is already set.
#  995|->                                 return NULL;
#  996|                           }
#  997|                   }

Error: RESOURCE_LEAK (CWE-772): [#def14]
python-dmidecode-3.12.2/src/xmlpythonizer.c:1031: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1031: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1050: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
# 1048|                           xpctx = xmlXPathNewContext(xpdoc);
# 1049|                           if( xpctx == NULL ) {
# 1050|->                                 PyReturnError(PyExc_MemoryError, "Could not setup new XPath context");
# 1051|                           }
# 1052|                           xpctx->node = data_n;

Error: RESOURCE_LEAK (CWE-772): [#def15]
python-dmidecode-3.12.2/src/xmlpythonizer.c:1054: alloc_fn: Storage is returned from allocation function "_get_xpath_values".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1054: var_assign: Assigning: "xpo" = storage returned from "_get_xpath_values(xpctx, map_p->rootpath)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1065: leaked_storage: Variable "xpo" going out of scope leaks the storage it points to.
# 1063|                                                           // Exit if we get NULL - something is wrong
# 1064|                                                           //and exception is set
# 1065|->                                                         return NULL;
# 1066|                                                   }
# 1067|                                           }

Error: RESOURCE_LEAK (CWE-772): [#def16]
python-dmidecode-3.12.2/src/xmlpythonizer.c:1031: alloc_fn: Storage is returned from allocation function "malloc".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1031: var_assign: Assigning: "key" = storage returned from "malloc(258UL)".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1059: identity_transfer: Passing "key" as argument 2 to function "_get_key_value", which returns that argument.
python-dmidecode-3.12.2/src/xmlpythonizer.c:1059: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1059: identity_transfer: Passing "key" as argument 2 to function "_get_key_value", which returns that argument.
python-dmidecode-3.12.2/src/xmlpythonizer.c:1059: noescape: Resource "key" is not freed or pointed-to in "_get_key_value".
python-dmidecode-3.12.2/src/xmlpythonizer.c:1087: leaked_storage: Variable "key" going out of scope leaks the storage it points to.
# 1085|                                   // Exit if we get NULL - something is wrong
# 1086|                                   //and exception is set
# 1087|->                                 return NULL;
# 1088|                           }
# 1089|                   }

Error: CONSTANT_EXPRESSION_RESULT (CWE-569): [#def1]
python-dmidecode-3.12.2/src/dmidecode.c:225: logical_vs_bitwise: The expression "16 && i < h->length - (row << 4)" is suspicious because it performs a Boolean operation on a constant other than 0 or 1.
#  223|                   memset(tmp_s, 0, (h->length * 2) + 2);
#  224|
#  225|->                 for(i = 0; i < (16 && i < h->length - (row << 4)); i++) {
#  226|                           snprintf(tmp_s + strlen(tmp_s), (h->length * 2)-strlen(tmp_s),
#  227|                                    "0x%02x", (h->data)[(row << 4) + i]);


Error: MISSING_COMMA: [#def3]
python-dmidecode-3.12.2/src/dmidecode.c:1375: missing_comma: In the initialization of "upgrade", a suspicious concatenated string ""Socket BGA1288Socket rPGA988B"" is produced due to a missing comma between lines.
python-dmidecode-3.12.2/src/dmidecode.c:1375: remediation: Did you intend to separate these two string literals with a comma?
# 1373|                   "Socket LGA1567",
# 1374|                   "Socket PGA988A",
# 1375|->                 "Socket BGA1288"        /* 0x20 */
# 1376|                   "Socket rPGA988B",
# 1377|                   "Socket BGA1023",
                                                                                                                                                                                                            
Error: MISSING_COMMA: [#def4]
python-dmidecode-3.12.2/src/dmidecode.c:1843: missing_comma: In the initialization of "type", a suspicious concatenated string ""64-way Set-associative20-way Set-associative"" is produced due to a missing between lines.
python-dmidecode-3.12.2/src/dmidecode.c:1843: remediation: Did you intend to separate these two string literals with a comma?
                                                                                                                                                                                                            
Error: MISSING_COMMA: [#def6]
python-dmidecode-3.12.2/src/dmidecode.c:2868: missing_comma: In the initialization of "type", a suspicious concatenated string ""DDR3FBD2"" is produced.
python-dmidecode-3.12.2/src/dmidecode.c:2868: remediation: Did you intend to separate these two string literals with a comma?
# 2866|                   "Reserved",
# 2867|                   "Reserved",
# 2868|->                 "DDR3"
# 2869|                   "FBD2"          /* 0x19 */
# 2870|           };
# 1841|                   "32-way Set-associative",
# 1842|                   "48-way Set-associative",
# 1843|->                 "64-way Set-associative"        /* 0x0D */
# 1844|                   "20-way Set-associative"        /* 0x0E */



python-dmidecode-3.12.2/src/dmierror.c:55:9: warning[-Wanalyzer-possible-null-argument]: use of possibly-NULL buf where non-null expected
/usr/include/python3.9/Python.h:30: included_from: Included from here.
python-dmidecode-3.12.2/src/dmierror.c:32: included_from: Included from here.
/usr/include/string.h:61:14: note: argument 1 of ^?^?^?memset^?^?^? must be non-null
#   53|           va_start(ap, fmt);
#   54|           buf = (char *) malloc(4098);
#   55|->         memset(buf, 0, 4098);
#   56|
#   57|           if( buf == NULL ) {

Error: FORWARD_NULL (CWE-476): [#def23]
python-dmidecode-3.12.2/src/dmilog.c:48: var_compare_op: Comparing "ret" to null implies that "ret" might be null.
python-dmidecode-3.12.2/src/dmilog.c:51: var_deref_op: Dereferencing null pointer "ret".
#   49|             fprintf(stderr, "** ERROR **  Could not allocate memory for log data\n");
#   50|     }
#   51|->   ret->level = -1; // Initialised - chain header pointer always have -1.
#   52|     return ret;
#   53|   }
                                                                                                                                                                           
Error: CLANG_WARNING: [#def24]
python-dmidecode-3.12.2/src/dmilog.c:51:13: warning[core.NullDereference]: Access to field 'level' results in a dereference of a null pointer (loaded from variable 'ret')
#   49|             fprintf(stderr, "** ERROR **  Could not allocate memory for log data\n");
#   50|     }
#   51|->   ret->level = -1; // Initialised - chain header pointer always have -1.
#   52|     return ret;
#   53|   }
                                                                                                                                                                           
Error: GCC_ANALYZER_WARNING (CWE-476): [#def25]
python-dmidecode-3.12.2/src/dmilog.c: scope_hint: In function 'log_init'
python-dmidecode-3.12.2/src/dmilog.c:51:20: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ret'
#   49|             fprintf(stderr, "** ERROR **  Could not allocate memory for log data\n");
#   50|     }
#   51|->   ret->level = -1; // Initialised - chain header pointer always have -1.
#   52|     return ret;
#   53|   }
                                                                                                                                                                           
Error: GCC_ANALYZER_WARNING (CWE-476): [#def26]
python-dmidecode-3.12.2/src/dmilog.c: scope_hint: In function ^?^?^?log_init^?^?^?
python-dmidecode-3.12.2/src/dmilog.c:51:20: warning[-Wanalyzer-null-dereference]: dereference of NULL ^?^?^?ret^?^?^?
#   49|             fprintf(stderr, "** ERROR **  Could not allocate memory for log data\n");
#   50|     }
#   51|->   ret->level = -1; // Initialised - chain header pointer always have -1.
#   52|     return ret;
#   53|   }

Error: GCC_ANALYZER_WARNING (CWE-688): [#def20]
python-dmidecode-3.12.2/src/dmidecodemodule.c:828:9: warning[-Wanalyzer-possible-null-argument]: use of possibly-NULL opt where non-null expected
/usr/include/python3.9/Python.h:30: included_from: Included from here.
python-dmidecode-3.12.2/src/dmidecodemodule.c:42: included_from: Included from here.
/usr/include/string.h:61:14: note: argument 1 of memset must be non-null

Scan Properties
analyzer-version-clang	11.1.0
analyzer-version-coverity	2020.12
analyzer-version-cppcheck	2.1
analyzer-version-gcc	11.0.0
analyzer-version-gcc-analyzer	11.0.0
analyzer-version-shellcheck	0.7.1
cov-compilation-unit-count	20
cov-compilation-unit-ratio	100
cov-lines-processed	36813
cov-time-elapsed-analysis	00:00:06
exit-code	0
host	cov04.lab.eng.brq.redhat.com
known-false-positives	/usr/share/csmock/known-false-positives.js
mock-config	rhel-9-alpha-x86_64
project-name	python-dmidecode-3.12.2-23.el9
store-results-to	/tmp/tmpLcf2Y8/python-dmidecode-3.12.2-23.el9.tar.xz
time-created	2021-02-23 01:11:11
time-finished	2021-02-23 01:13:03
tool	csmock
tool-args	'/bin/csmock' '-t' 'cppcheck,gcc,shellcheck,clang,coverity' '-r' 'rhel-9-alpha-x86_64' '-o' '/tmp/tmpLcf2Y8/python-dmidecode-3.12.2-23.el9.tar.xz' '--cov-analyze-java' '--cov-analyze-opts=--security --concurrency' '--use-host-cppcheck' '--gcc-analyze' '--cov-use-instance' '/opt/cov-sa-2020.12' '/tmp/tmpLcf2Y8/python-dmidecode-3.12.2-23.el9.src.rpm'
tool-version	csmock-2.7.0.20210216.090633.gd7fc8c2.internal-1.el7
```