### PR TITLE
Fix the failure of reporting "undefined symbol: dmixml_GetContent"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@
 #. $AutoHeaderSerial::20100225                                                 $
 #. ******* AUTOHEADER END v1.2 *******
 
-PY_BIN  := python2
+PY_BIN  := python3
 VERSION := $(shell cd src;$(PY_BIN) -c "from setup_common import *; print(get_version());")
 PACKAGE := python-dmidecode
 PY_VER  := $(shell $(PY_BIN) -c 'import sys; print("%d.%d"%sys.version_info[0:2])')

--- a/src/dmixml.h
+++ b/src/dmixml.h
@@ -75,8 +75,8 @@ xmlNode *__dmixml_FindNodeByAttr(xmlNode *, const char *, const char *, const ch
 
 
 xmlNode *dmixml_FindNode(xmlNode *, const char *key);
-inline char *dmixml_GetContent(xmlNode *node);
-inline char *dmixml_GetNodeContent(xmlNode *node, const char *key);
+char *dmixml_GetContent(xmlNode *node);
+char *dmixml_GetNodeContent(xmlNode *node, const char *key);
 char *dmixml_GetXPathContent(Log_t *logp, char *buf, size_t buflen, xmlXPathObject *xpo, int idx);
 
 #endif

--- a/src/xmlpythonizer.c
+++ b/src/xmlpythonizer.c
@@ -603,7 +603,7 @@ ptzMAP *dmiMAP_ParseMappingXML_GroupName(Log_t *logp, xmlDoc *xmlmap, const char
  * @param const char * String which contains the value to be converted to a Python value
  * @return PyObject *  The converted value as a Python object
  */
-inline PyObject *StringToPyObj(Log_t *logp, ptzMAP *val_m, const char *instr) {
+static inline PyObject *StringToPyObj(Log_t *logp, ptzMAP *val_m, const char *instr) {
         PyObject *value;
         const char *workstr = NULL;
 
@@ -772,7 +772,7 @@ char *_get_key_value(Log_t *logp, char *key, size_t buflen,
  * @param ptzMAP*           Pointer to the current mapping entry being parsed
  * @param xmlXPathObject*   Pointer to XPath object containing the data value(s) for the dictionary
  */
-inline void _add_xpath_result(Log_t *logp, PyObject *pydat, xmlXPathContext *xpctx, ptzMAP *map_p, xmlXPathObject *value) {
+static inline void _add_xpath_result(Log_t *logp, PyObject *pydat, xmlXPathContext *xpctx, ptzMAP *map_p, xmlXPathObject *value) {
         int i = 0;
         char *key = NULL;
         char *val = NULL;

--- a/unit-tests/Makefile
+++ b/unit-tests/Makefile
@@ -1,4 +1,4 @@
-PY_BIN := python2
+PY_BIN := python3
 
 test :
 	$(PY_BIN) unit -vv


### PR DESCRIPTION
Changes:
[1] Fix the failure of reporting "undefined symbol: dmixml_GetContent"
[2] use python3 by default