### PR TITLE
fix "src/dmidecodemodule.c:828:9 warning[-Wanalyzer-possible-null-argument]: use of possibly-NULL opt where non-null expected"

### DIFF
--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -825,6 +825,9 @@ initdmidecodemod(void)
         xmlXPathInit();
 
         opt = (options *) malloc(sizeof(options)+2);
+        if (opt == NULL)
+                MODINITERROR;
+
         memset(opt, 0, sizeof(options)+2);
         init(opt);
 #ifdef IS_PY3K


### PR DESCRIPTION

Fix the following error found by covscan,

    Error: GCC_ANALYZER_WARNING (CWE-688): [#def20]
    python-dmidecode-3.12.2/src/dmidecodemodule.c:828:9: warning[-Wanalyzer-possible-null-argument]: use of possibly-NULL opt where non-null expected
    /usr/include/python3.9/Python.h:30: included_from: Included from here.
    python-dmidecode-3.12.2/src/dmidecodemodule.c:42: included_from: Included from here.
    /usr/include/string.h:61:14: note: argument 1 of memset must be non-null