### PR TITLE
fix bug: Failed to open memory buffer (/dev/mem): Permission denied

### DIFF
--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -52,11 +52,14 @@
 #include "version.h"
 #include "dmidump.h"
 #include <mcheck.h>
+#include <stdio.h>
 
 #if (PY_VERSION_HEX < 0x03030000)
-char *PyUnicode_AsUTF8(PyObject *unicode) {
+char *PyUnicode_AsUTF8(PyObject *unicode)
+{
         PyObject *as_bytes = PyUnicode_AsUTF8String(unicode);
-        if (!as_bytes) {
+        if (!as_bytes)
+        {
                 return NULL;
         }
 
@@ -66,7 +69,9 @@ char *PyUnicode_AsUTF8(PyObject *unicode) {
 
 static void init(options *opt)
 {
-        opt->devmem = DEFAULT_MEM_DEV;
+        int efi;
+        size_t fp;
+
         opt->dumpfile = NULL;
         opt->flags = 0;
         opt->type = -1;
@@ -75,8 +80,19 @@ static void init(options *opt)
         opt->python_xml_map = strdup(PYTHON_XML_MAP);
         opt->logdata = log_init();
 
+        efi = address_from_efi(opt->logdata, &fp);
+        if (efi == EFI_NOT_FOUND)
+        {
+                opt->devmem = DEFAULT_MEM_DEV;
+        }
+        else
+        {
+                opt->devmem = SYS_TABLE_FILE;
+        }
+
         /* sanity check */
-        if(sizeof(u8) != 1 || sizeof(u16) != 2 || sizeof(u32) != 4 || '\0' != 0) {
+        if (sizeof(u8) != 1 || sizeof(u16) != 2 || sizeof(u32) != 4 || '\0' != 0)
+        {
                 log_append(opt->logdata, LOGFL_NORMAL, LOG_WARNING,
                            "%s: compiler incompatibility", "dmidecodemodule");
         }
@@ -84,30 +100,33 @@ static void init(options *opt)
 
 int parse_opt_type(Log_t *logp, const char *arg)
 {
-        while(*arg != '\0') {
+        while (*arg != '\0')
+        {
                 int val;
                 char *next;
 
                 val = strtoul(arg, &next, 0);
-                if(next == arg) {
+                if (next == arg)
+                {
                         log_append(logp, LOGFL_NODUPS, LOG_ERR, "Invalid type keyword: %s", arg);
                         return -1;
                 }
-                if(val > 0xff) {
+                if (val > 0xff)
+                {
                         log_append(logp, LOGFL_NODUPS, LOG_ERR, "Invalid type number: %i", val);
                         return -1;
                 }
 
-                if( val >= 0 ) {
+                if (val >= 0)
+                {
                         return val;
                 }
                 arg = next;
-                while(*arg == ',' || *arg == ' ')
+                while (*arg == ',' || *arg == ' ')
                         arg++;
         }
         return -1;
 }
-
 
 xmlNode *dmidecode_get_version(options *opt)
 {
@@ -116,209 +135,435 @@ xmlNode *dmidecode_get_version(options *opt)
         int efi;
         u8 *buf = NULL;
         xmlNode *ver_n = NULL;
+        size_t size;
 
         /* Set default option values */
-        if( opt->devmem == NULL ) {
-                opt->devmem = DEFAULT_MEM_DEV;
+        if (opt->devmem == NULL)
+        {
+                efi = address_from_efi(opt->logdata, &fp);
+                if (efi == EFI_NOT_FOUND)
+                {
+                        opt->devmem = DEFAULT_MEM_DEV;
+                }
+                else
+                {
+                        opt->devmem = SYS_TABLE_FILE;
+                }
         }
 
         /* Read from dump if so instructed */
-        if(opt->dumpfile != NULL) {
-                //. printf("Reading SMBIOS/DMI data from file %s.\n", dumpfile);
-                if((buf = mem_chunk(opt->logdata, 0, 0x20, opt->dumpfile)) != NULL) {
-                        if(memcmp(buf, "_SM_", 4) == 0) {
-                                ver_n = smbios_decode_get_version(buf, opt->dumpfile);
-                                if( dmixml_GetAttrValue(ver_n, "unknown") == NULL ) {
-                                        found++;
-                                }
-                        } else if(memcmp(buf, "_DMI_", 5) == 0) {
-                                ver_n = legacy_decode_get_version(buf, opt->dumpfile);
-                                if( dmixml_GetAttrValue(ver_n, "unknown") == NULL ) {
-                                        found++;
-                                }
-                        }
-                }
-        } else {          /* Read from /dev/mem */
-                /* First try EFI (ia64, Intel-based Mac) */
-                efi = address_from_efi(opt->logdata, &fp);
-                if(efi == EFI_NOT_FOUND) {
-                        /* Fallback to memory scan (x86, x86_64) */
-                        if((buf = mem_chunk(opt->logdata, 0xF0000, 0x10000, opt->devmem)) != NULL) {
-                                for(fp = 0; fp <= 0xFFF0; fp += 16) {
-                                        if(memcmp(buf + fp, "_SM_", 4) == 0 && fp <= 0xFFE0) {
-                                                ver_n = smbios_decode_get_version(buf + fp, opt->devmem);
-                                                if( dmixml_GetAttrValue(ver_n, "unknown") == NULL ) {
-                                                        found++;
-                                                }
-                                                fp += 16;
-                                        } else if(memcmp(buf + fp, "_DMI_", 5) == 0) {
-                                                ver_n = legacy_decode_get_version (buf + fp, opt->devmem);
-                                                if( dmixml_GetAttrValue(ver_n, "unknown") == NULL ) {
-                                                        found++;
-                                                }
-                                        }
-                                }
-                        }
-                } else if(efi == EFI_NO_SMBIOS) {
+        if (opt->dumpfile != NULL)
+        {
+                if ((buf = mem_chunk(opt->logdata, 0, 0x20, opt->dumpfile)) == NULL)
+                {
                         ver_n = NULL;
-                } else {
-                        // Process as EFI
-                        if((buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem)) != NULL) {
-                                ver_n = smbios_decode_get_version(buf, opt->devmem);
-                                if( dmixml_GetAttrValue(ver_n, "unknown") == NULL ) {
-                                        found++;
-                                }
-                                //. TODO: dmixml_AddAttribute(dmixml_n, "efi_address", efiAddress);
+                        goto exit_free;
+                }
+                if (memcmp(buf, "_SM3_", 5) == 0)
+                {
+                        ver_n = smbios3_decode_get_version(buf, opt->dumpfile);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        {
+                                found++;
+                        }
+                }
+                else if (memcmp(buf, "_SM_", 4) == 0)
+                {
+                        ver_n = smbios_decode_get_version(buf, opt->dumpfile);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        {
+                                found++;
+                        }
+                }
+                else if (memcmp(buf, "_DMI_", 5) == 0)
+                {
+                        ver_n = legacy_decode_get_version(buf, opt->dumpfile);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        {
+                                found++;
+                        }
+                }
+                goto done;
+        }
+
+        /*
+         * First try reading from sysfs tables.  The entry point file could
+         * contain one of several types of entry points, so read enough for
+         * the largest one, then determine what type it contains.
+         */
+        size = 0x20;
+        if ((buf = read_file(opt->logdata, 0, &size, SYS_ENTRY_FILE)) != NULL)
+        {
+                if (size >= 24 && memcmp(buf, "_SM3_", 5) == 0)
+                {
+                        ver_n = smbios3_decode_get_version(buf, opt->devmem);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                                found++;
+                }
+                else if (size >= 31 && memcmp(buf, "_SM_", 4) == 0)
+                {
+                        ver_n = smbios_decode_get_version(buf, opt->devmem);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                                found++;
+                }
+                else if (size >= 15 && memcmp(buf, "_DMI_", 5) == 0)
+                {
+                        ver_n = legacy_decode_get_version(buf, opt->devmem);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                                found++;
+                }
+                if (found)
+                        goto done;
+        }
+        else
+        {
+                ver_n = NULL;
+                goto exit_free;
+        }
+
+        /* Next try EFI (ia64, Intel-based Mac) */
+        efi = address_from_efi(opt->logdata, &fp);
+        switch (efi)
+        {
+        case EFI_NOT_FOUND:
+                goto memory_scan;
+        case EFI_NO_SMBIOS:
+                ver_n = NULL;
+                goto exit_free;
+        }
+
+        if (buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem) == NULL)
+        {
+                ver_n = NULL;
+                goto exit_free;
+        }
+
+        if (memcmp(buf, "_SM3_", 5) == 0)
+        {
+                ver_n = smbios3_decode_get_version(buf, opt->devmem);
+                if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        found++;
+        }
+        else if (memcmp(buf, "_SM_", 4) == 0)
+        {
+                ver_n = smbios_decode_get_version(buf, opt->devmem);
+                if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        found++;
+        }
+
+        goto done;
+
+memory_scan:
+#if defined __i386__ || defined __x86_64__
+        /* Fallback to memory scan (x86, x86_64) */
+        if ((buf = mem_chunk(opt->logdata, 0xF0000, 0x10000, opt->devmem)) == NULL)
+        {
+                ver_n = NULL;
+                goto exit_free;
+        }
+
+        /* Look for a 64-bit entry point first */
+        for (fp = 0; fp <= 0xFFE0; fp += 16)
+        {
+                if (memcmp(buf + fp, "_SM3_", 5) == 0)
+                {
+                        ver_n = smbios3_decode_get_version(buf + fp, opt->devmem);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        {
+                                found++;
+                                goto done;
                         }
                 }
         }
-        if( buf != NULL ) {
-                free(buf);
+
+        /* If none found, look for a 32-bit entry point */
+        for (fp = 0; fp <= 0xFFF0; fp += 16)
+        {
+                if (memcmp(buf + fp, "_SM_", 4) == 0 && fp <= 0xFFE0)
+                {
+                        ver_n = smbios_decode_get_version(buf + fp, opt->devmem);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        {
+                                found++;
+                                goto done;
+                        }
+                        fp += 16;
+                }
+                else if (memcmp(buf + fp, "_DMI_", 5) == 0)
+                {
+                        ver_n = legacy_decode_get_version(buf + fp, opt->devmem);
+                        if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                        {
+                                found++;
+                                goto done;
+                        }
+                }
         }
-        if( !found ) {
+#endif
+
+done:
+        if (!found)
+        {
                 log_append(opt->logdata, LOGFL_NODUPS, LOG_WARNING,
                            "No SMBIOS nor DMI entry point found, sorry.");
         }
+
+exit_free:
+        if (buf != NULL)
+                free(buf);
+
         return ver_n;
 }
 
-int dmidecode_get_xml(options *opt, xmlNode* dmixml_n)
+int dmidecode_get_xml(options *opt, xmlNode *dmixml_n)
 {
         assert(dmixml_n != NULL);
-        if(dmixml_n == NULL) {
+        if (dmixml_n == NULL)
+        {
                 return 0;
         }
-        //mtrace();
+        // mtrace();
 
         int ret = 0;
         int found = 0;
         size_t fp;
         int efi;
         u8 *buf = NULL;
+        size_t size;
 
         const char *f = opt->dumpfile ? opt->dumpfile : opt->devmem;
-        if(access(f, R_OK) < 0) {
+        if (access(f, R_OK) < 0)
+        {
                 log_append(opt->logdata, LOGFL_NORMAL,
                            LOG_WARNING, "Permission denied to memory file/device (%s)", f);
                 return 0;
         }
 
         /* Read from dump if so instructed */
-        if(opt->dumpfile != NULL) {
-                //  printf("Reading SMBIOS/DMI data from file %s.\n", dumpfile);
-                if((buf = mem_chunk(opt->logdata, 0, 0x20, opt->dumpfile)) != NULL) {
-                        if(memcmp(buf, "_SM_", 4) == 0) {
-                                if(smbios_decode(opt->logdata, opt->type, buf, opt->dumpfile, dmixml_n))
-                                        found++;
-                        } else if(memcmp(buf, "_DMI_", 5) == 0) {
-                                if(legacy_decode(opt->logdata, opt->type, buf, opt->dumpfile, dmixml_n))
-                                        found++;
-                        }
-                } else {
+        if (opt->dumpfile != NULL)
+        {
+                if ((buf = mem_chunk(opt->logdata, 0, 0x20, opt->dumpfile)) == NULL)
+                {
                         ret = 1;
+                        goto exit_free;
                 }
-        } else {                /* Read from /dev/mem */
-                /* First try EFI (ia64, Intel-based Mac) */
-                efi = address_from_efi(opt->logdata, &fp);
-                if(efi == EFI_NOT_FOUND) {
-                        /* Fallback to memory scan (x86, x86_64) */
-                        if((buf = mem_chunk(opt->logdata, 0xF0000, 0x10000, opt->devmem)) != NULL) {
-                                for(fp = 0; fp <= 0xFFF0; fp += 16) {
-                                        if(memcmp(buf + fp, "_SM_", 4) == 0 && fp <= 0xFFE0) {
-                                                if(smbios_decode(opt->logdata, opt->type,
-                                                                 buf + fp, opt->devmem, dmixml_n)) {
-                                                        found++;
-                                                        fp += 16;
-                                                }
-                                        } else if(memcmp(buf + fp, "_DMI_", 5) == 0) {
-                                                if(legacy_decode(opt->logdata, opt->type,
-                                                                 buf + fp, opt->devmem, dmixml_n))
-                                                        found++;
-                                        }
-                                }
-                        } else
-                                ret = 1;
-                } else if(efi == EFI_NO_SMBIOS) {
-                        ret = 1;
-                } else {
-                        if((buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem)) == NULL)
-                                ret = 1;
-                        else if(smbios_decode(opt->logdata, opt->type, buf, opt->devmem, dmixml_n))
+                if (memcmp(buf, "_SM3_", 5) == 0)
+                {
+                        if (smbios3_decode(opt->logdata, opt->type, buf, opt->dumpfile, 0, dmixml_n))
                                 found++;
-                        //  TODO: dmixml_AddAttribute(dmixml_n, "efi_address", "0x%08x", efiAddress);
+                }
+                else if (memcmp(buf, "_SM_", 4) == 0)
+                {
+
+                        if (smbios_decode(opt->logdata, opt->type, buf, opt->dumpfile, 0, dmixml_n))
+                                found++;
+                }
+                else if (memcmp(buf, "_DMI_", 5) == 0)
+                {
+                        if (legacy_decode(opt->logdata, opt->type, buf, opt->dumpfile, 0, dmixml_n))
+                                found++;
+                }
+                goto done;
+        }
+
+        /*
+         * First try reading from sysfs tables.  The entry point file could
+         * contain one of several types of entry points, so read enough for
+         * the largest one, then determine what type it contains.
+         */
+        size = 0x20;
+        if ((buf = read_file(opt->logdata, 0, &size, SYS_ENTRY_FILE)) != NULL)
+        {
+                if (size >= 24 && memcmp(buf, "_SM3_", 5) == 0)
+                {
+                        if (smbios3_decode(opt->logdata, opt->type, buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET, dmixml_n))
+                                found++;
+                }
+                else if (size >= 31 && memcmp(buf, "_SM_", 4) == 0)
+                {
+                        if (smbios_decode(opt->logdata, opt->type, buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET, dmixml_n))
+                                found++;
+                }
+                else if (size >= 15 && memcmp(buf, "_DMI_", 5) == 0)
+                {
+                        if (legacy_decode(opt->logdata, opt->type, buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET, dmixml_n))
+                                found++;
+                }
+                if (found)
+                        goto done;
+        }
+        else
+        {
+                ret = 1;
+                goto done;
+        }
+
+        /* Next try EFI (ia64, Intel-based Mac) */
+        efi = address_from_efi(opt->logdata, &fp);
+        switch (efi)
+        {
+        case EFI_NOT_FOUND:
+                goto memory_scan;
+        case EFI_NO_SMBIOS:
+                ret = 1;
+                goto exit_free;
+        }
+
+        if (buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem) == NULL)
+        {
+                ret = 1;
+                goto exit_free;
+        }
+
+        if (memcmp(buf, "_SM3_", 5) == 0)
+        {
+                if (smbios3_decode(opt->logdata, opt->type,
+                                   buf + fp, opt->devmem, 0, dmixml_n))
+                        found++;
+        }
+        else if (memcmp(buf, "_SM_", 4) == 0)
+        {
+                if (smbios_decode(opt->logdata, opt->type,
+                                  buf + fp, opt->devmem, 0, dmixml_n))
+                        found++;
+        }
+        goto done;
+
+memory_scan:
+#if defined __i386__ || defined __x86_64__
+        if ((buf = mem_chunk(opt->logdata, 0xF0000, 0x10000, opt->devmem)) == NULL)
+        {
+                ret = 1;
+                goto exit_free;
+        }
+
+        /* Look for a 64-bit entry point first */
+        for (fp = 0; fp <= 0xFFE0; fp += 16)
+        {
+                if (memcmp(buf + fp, "_SM3_", 5) == 0)
+                {
+                        if (smbios3_decode(opt->logdata, opt->type,
+                                           buf + fp, opt->devmem, 0, dmixml_n))
+                        {
+                                found++;
+                                goto done;
+                        }
                 }
         }
-        if(ret == 0) {
-                free(buf);
+
+        /* If none found, look for a 32-bit entry point */
+        for (fp = 0; fp <= 0xFFF0; fp += 16)
+        {
+                if (memcmp(buf + fp, "_SM_", 4) == 0 && fp <= 0xFFE0)
+                {
+                        if (smbios_decode(opt->logdata, opt->type,
+                                          buf + fp, opt->devmem, 0, dmixml_n))
+                        {
+                                found++;
+                                goto done;
+                        }
+                }
+                else if (memcmp(buf + fp, "_DMI_", 5) == 0)
+                {
+                        if (legacy_decode(opt->logdata, opt->type,
+                                          buf + fp, opt->devmem, 0, dmixml_n))
+                                found++;
+                        goto done;
+                }
         }
-        //muntrace();
+#endif
+
+done:
+        if (!found)
+        {
+                log_append(opt->logdata, LOGFL_NODUPS, LOG_WARNING,
+                           "No SMBIOS nor DMI entry point found, sorry.");
+        }
+
+exit_free:
+        if (!found)
+                free(buf);
+
         return ret;
 }
 
-xmlNode* load_mappingxml(options *opt) {
-       if( opt->mappingxml == NULL ) {
+xmlNode *load_mappingxml(options *opt)
+{
+        if (opt->mappingxml == NULL)
+        {
                 // Load mapping into memory
                 opt->mappingxml = xmlReadFile(opt->python_xml_map, NULL, 0);
-                if( opt->mappingxml == NULL ) {
+                if (opt->mappingxml == NULL)
+                {
                         PyReturnError(PyExc_IOError, "Could not open tje XML mapping file '%s'",
                                       opt->python_xml_map);
                 }
-       }
-       return dmiMAP_GetRootElement(opt->mappingxml);
+        }
+        return dmiMAP_GetRootElement(opt->mappingxml);
 }
 
-xmlNode *__dmidecode_xml_getsection(options *opt, const char *section) {
+xmlNode *__dmidecode_xml_getsection(options *opt, const char *section)
+{
         xmlNode *dmixml_n = NULL;
         xmlNode *group_n = NULL;
 
-        dmixml_n = xmlNewNode(NULL, (xmlChar *) "dmidecode");
-        assert( dmixml_n != NULL );
+        dmixml_n = xmlNewNode(NULL, (xmlChar *)"dmidecode");
+        assert(dmixml_n != NULL);
         // Append DMI version info
-        if( opt->dmiversion_n != NULL ) {
+        if (opt->dmiversion_n != NULL)
+        {
                 xmlAddChild(dmixml_n, xmlCopyNode(opt->dmiversion_n, 1));
         }
 
         // Fetch the Mapping XML file
-        if( (group_n = load_mappingxml(opt)) == NULL) {
+        if ((group_n = load_mappingxml(opt)) == NULL)
+        {
                 xmlFreeNode(dmixml_n);
                 // Exception already set by calling function
                 return NULL;
         }
 
         // Find the section in the XML containing the group mappings
-        if( (group_n = dmixml_FindNode(group_n, "GroupMapping")) == NULL ) {
+        if ((group_n = dmixml_FindNode(group_n, "GroupMapping")) == NULL)
+        {
                 PyReturnError(PyExc_LookupError,
                               "Could not find the GroupMapping section in the XML mapping");
         }
 
         // Find the XML node containing the Mapping section requested to be decoded
-        if( (group_n = dmixml_FindNodeByAttr(group_n, "Mapping", "name", section)) == NULL ) {
+        if ((group_n = dmixml_FindNodeByAttr(group_n, "Mapping", "name", section)) == NULL)
+        {
                 PyReturnError(PyExc_LookupError,
                               "Could not find the XML->Python Mapping section for '%s'", section);
         }
 
-        if( group_n->children == NULL ) {
+        if (group_n->children == NULL)
+        {
                 PyReturnError(PyExc_RuntimeError,
                               "Mapping is empty for the '%s' section in the XML mapping", section);
         }
 
         // Go through all TypeMap's belonging to this Mapping section
-        foreach_xmlnode(dmixml_FindNode(group_n, "TypeMap"), group_n) {
+        foreach_xmlnode(dmixml_FindNode(group_n, "TypeMap"), group_n)
+        {
                 char *typeid = dmixml_GetAttrValue(group_n, "id");
 
-                if( group_n->type != XML_ELEMENT_NODE ) {
+                if (group_n->type != XML_ELEMENT_NODE)
+                {
                         continue;
                 }
 
                 // The children of <Mapping> tags must only be <TypeMap> and
                 // they must have an 'id' attribute
-                if( (typeid == NULL) || (xmlStrcmp(group_n->name, (xmlChar *) "TypeMap") != 0) ) {
+                if ((typeid == NULL) || (xmlStrcmp(group_n->name, (xmlChar *)"TypeMap") != 0))
+                {
                         PyReturnError(PyExc_RuntimeError, "Invalid TypeMap node in mapping XML");
                 }
 
                 // Parse the typeid string to a an integer
                 opt->type = parse_opt_type(opt->logdata, typeid);
-                if(opt->type == -1) {
+                if (opt->type == -1)
+                {
                         char *err = log_retrieve(opt->logdata, LOG_ERR);
                         log_clear_partial(opt->logdata, LOG_ERR, 0);
                         _pyReturnError(PyExc_RuntimeError, "Invalid type id '%s' -- %s", typeid, err);
@@ -327,11 +572,12 @@ xmlNode *__dmidecode_xml_getsection(options *opt, const char *section) {
                 }
 
                 // Parse the DMI data and put the result into dmixml_n node chain.
-                if( dmidecode_get_xml(opt, dmixml_n) != 0 ) {
+                if (dmidecode_get_xml(opt, dmixml_n) != 0)
+                {
                         PyReturnError(PyExc_RuntimeError, "Error decoding DMI data");
                 }
         }
-#if 0  // DEBUG - will dump generated XML to stdout
+#if 0 // DEBUG - will dump generated XML to stdout
         xmlDoc *doc = xmlNewDoc((xmlChar *) "1.0");
         xmlDocSetRootElement(doc, xmlCopyNode(dmixml_n, 1));
         xmlSaveFormatFileEnc("-", doc, "UTF-8", 1);
@@ -342,26 +588,40 @@ xmlNode *__dmidecode_xml_getsection(options *opt, const char *section) {
 
 static PyObject *dmidecode_get_group(options *opt, const char *section)
 {
+        int efi;
+        size_t fp;
         PyObject *pydata = NULL;
         xmlNode *dmixml_n = NULL;
         ptzMAP *mapping = NULL;
 
         /* Set default option values */
-        if( opt->devmem == NULL ) {
-                opt->devmem = DEFAULT_MEM_DEV;
+        if (opt->devmem == NULL)
+        {
+                efi = address_from_efi(opt->logdata, &fp);
+                if (efi == EFI_NOT_FOUND)
+                {
+                        opt->devmem = DEFAULT_MEM_DEV;
+                }
+                else
+                {
+                        opt->devmem = SYS_TABLE_FILE;
+                }
         }
+
         opt->flags = 0;
 
         // Decode the dmidata into an XML node
         dmixml_n = __dmidecode_xml_getsection(opt, section);
-        if( dmixml_n == NULL ) {
+        if (dmixml_n == NULL)
+        {
                 // Exception already set
                 return NULL;
         }
 
         // Convert the retrieved XML nodes to a Python dictionary
         mapping = dmiMAP_ParseMappingXML_GroupName(opt->logdata, opt->mappingxml, section);
-        if( mapping == NULL ) {
+        if (mapping == NULL)
+        {
                 // Exception already set
                 xmlFreeNode(dmixml_n);
                 return NULL;
@@ -377,39 +637,51 @@ static PyObject *dmidecode_get_group(options *opt, const char *section)
         return pydata;
 }
 
-
 xmlNode *__dmidecode_xml_gettypeid(options *opt, int typeid)
 {
+        int efi;
+        size_t fp;
         xmlNode *dmixml_n = NULL;
 
         /* Set default option values */
-        if( opt->devmem == NULL ) {
-                opt->devmem = DEFAULT_MEM_DEV;
+        if (opt->devmem == NULL)
+        {
+                efi = address_from_efi(opt->logdata, &fp);
+                if (efi == EFI_NOT_FOUND)
+                {
+                        opt->devmem = DEFAULT_MEM_DEV;
+                }
+                else
+                {
+                        opt->devmem = SYS_TABLE_FILE;
+                }
         }
         opt->flags = 0;
 
-        dmixml_n = xmlNewNode(NULL, (xmlChar *) "dmidecode");
-        assert( dmixml_n != NULL );
+        dmixml_n = xmlNewNode(NULL, (xmlChar *)"dmidecode");
+        assert(dmixml_n != NULL);
         // Append DMI version info
-        if( opt->dmiversion_n != NULL ) {
+        if (opt->dmiversion_n != NULL)
+        {
                 xmlAddChild(dmixml_n, xmlCopyNode(opt->dmiversion_n, 1));
         }
 
         // Fetch the Mapping XML file
-        if( load_mappingxml(opt) == NULL) {
+        if (load_mappingxml(opt) == NULL)
+        {
                 xmlFreeNode(dmixml_n);
                 return NULL;
         }
 
         // Parse the DMI data and put the result into dmixml_n node chain.
         opt->type = typeid;
-        if( dmidecode_get_xml(opt, dmixml_n) != 0 ) {
+        if (dmidecode_get_xml(opt, dmixml_n) != 0)
+        {
                 PyReturnError(PyExc_RuntimeError, "Error decoding DMI data");
         }
 
         return dmixml_n;
 }
-
 
 static PyObject *dmidecode_get_typeid(options *opt, int typeid)
 {
@@ -418,14 +690,16 @@ static PyObject *dmidecode_get_typeid(options *opt, int typeid)
         ptzMAP *mapping = NULL;
 
         dmixml_n = __dmidecode_xml_gettypeid(opt, typeid);
-        if( dmixml_n == NULL ) {
+        if (dmixml_n == NULL)
+        {
                 // Exception already set
                 return NULL;
         }
 
         // Convert the retrieved XML nodes to a Python dictionary
         mapping = dmiMAP_ParseMappingXML_TypeID(opt->logdata, opt->mappingxml, opt->type);
-        if( mapping == NULL ) {
+        if (mapping == NULL)
+        {
                 // FIXME:  Should we raise an exception here?
                 // Now it passes the unit-test
                 return PyDict_New();
@@ -441,44 +715,43 @@ static PyObject *dmidecode_get_typeid(options *opt, int typeid)
         return pydata;
 }
 
-
 // This global variable should only be available for the "first-entry" functions
 // which is defined in PyMethodDef DMIDataMethods[].
 options *global_options = NULL;
 
-static PyObject *dmidecode_get_bios(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_bios(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "bios");
 }
-static PyObject *dmidecode_get_system(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_system(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "system");
 }
-static PyObject *dmidecode_get_baseboard(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_baseboard(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "baseboard");
 }
-static PyObject *dmidecode_get_chassis(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_chassis(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "chassis");
 }
-static PyObject *dmidecode_get_processor(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_processor(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "processor");
 }
-static PyObject *dmidecode_get_memory(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_memory(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "memory");
 }
-static PyObject *dmidecode_get_cache(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_cache(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "cache");
 }
-static PyObject *dmidecode_get_connector(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_connector(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "connector");
 }
-static PyObject *dmidecode_get_slot(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_slot(PyObject *self, PyObject *args)
 {
         return dmidecode_get_group(global_options, "slot");
 }
@@ -486,31 +759,39 @@ static PyObject *dmidecode_get_slot(PyObject * self, PyObject * args)
 static PyObject *dmidecode_get_section(PyObject *self, PyObject *args)
 {
         char *section = NULL;
-        if (PyUnicode_Check(args)) {
+        if (PyUnicode_Check(args))
+        {
                 section = PyUnicode_AsUTF8(args);
-        } else if (PyBytes_Check(args)) {
+        }
+        else if (PyBytes_Check(args))
+        {
                 section = PyBytes_AsString(args);
         }
 
-        if( section != NULL ) {
+        if (section != NULL)
+        {
                 return dmidecode_get_group(global_options, section);
         }
         PyReturnError(PyExc_RuntimeError, "No section name was given");
 }
 
-static PyObject *dmidecode_get_type(PyObject * self, PyObject * args)
+static PyObject *dmidecode_get_type(PyObject *self, PyObject *args)
 {
         int typeid;
         PyObject *pydata = NULL;
 
-        if( PyArg_ParseTuple(args, (char *)"i", &typeid) ) {
-                if( (typeid < 0) || (typeid > 255) ) {
+        if (PyArg_ParseTuple(args, (char *)"i", &typeid))
+        {
+                if ((typeid < 0) || (typeid > 255))
+                {
                         Py_RETURN_FALSE;
                         // FIXME:  Should send exception instead
                         // PyReturnError(PyExc_RuntimeError, "Types are bound between 0 and 255 (inclusive)."
                         //               "Type value used was '%i'", typeid);
                 }
-        } else {
+        }
+        else
+        {
                 PyReturnError(PyExc_RuntimeError, "Type '%i' is not a valid type identifier%c", typeid);
         }
 
@@ -528,25 +809,31 @@ static PyObject *dmidecode_xmlapi(PyObject *self, PyObject *args, PyObject *keyw
         int type_query = -1;
 
         // Parse the keywords - we only support keywords, as this is an internal API
-        if( !PyArg_ParseTupleAndKeywords(args, keywds, "ss|si", keywordlist,
-                                         &qtype, &rtype, &sect_query, &type_query) ) {
+        if (!PyArg_ParseTupleAndKeywords(args, keywds, "ss|si", keywordlist,
+                                         &qtype, &rtype, &sect_query, &type_query))
+        {
                 return NULL;
         }
 
         // Check for sensible arguments and retrieve the xmlNode with DMI data
-        switch( *qtype ) {
+        switch (*qtype)
+        {
         case 's': // Section / GroupName
-                if( sect_query == NULL ) {
+                if (sect_query == NULL)
+                {
                         PyReturnError(PyExc_TypeError, "section keyword cannot be NULL")
                 }
                 dmixml_n = __dmidecode_xml_getsection(global_options, sect_query);
                 break;
 
         case 't': // TypeID / direct TypeMap
-                if( type_query < 0 ) {
+                if (type_query < 0)
+                {
                         PyReturnError(PyExc_TypeError,
                                       "typeid keyword must be set and must be a positive integer");
-                } else if( type_query > 255 ) {
+                }
+                else if (type_query > 255)
+                {
                         PyReturnError(PyExc_ValueError,
                                       "typeid keyword must be an integer between 0 and 255");
                 }
@@ -558,24 +845,27 @@ static PyObject *dmidecode_xmlapi(PyObject *self, PyObject *args, PyObject *keyw
         }
 
         // Check if we got any data
-        if( dmixml_n == NULL ) {
+        if (dmixml_n == NULL)
+        {
                 // Exception already set
                 return NULL;
         }
 
         // Check for sensible return type and wrap the correct type into a Python Object
-        switch( *rtype ) {
+        switch (*rtype)
+        {
         case 'n':
-                pydata = libxml_xmlNodePtrWrap((xmlNode *) dmixml_n);
+                pydata = libxml_xmlNodePtrWrap((xmlNode *)dmixml_n);
                 break;
 
         case 'd':
-                dmixml_doc = xmlNewDoc((xmlChar *) "1.0");
-                if( dmixml_doc == NULL ) {
+                dmixml_doc = xmlNewDoc((xmlChar *)"1.0");
+                if (dmixml_doc == NULL)
+                {
                         PyReturnError(PyExc_MemoryError, "Could not create new XML document");
                 }
                 xmlDocSetRootElement(dmixml_doc, dmixml_n);
-                pydata = libxml_xmlDocPtrWrap((xmlDoc *) dmixml_doc);
+                pydata = libxml_xmlDocPtrWrap((xmlDoc *)dmixml_doc);
                 break;
 
         default:
@@ -587,55 +877,65 @@ static PyObject *dmidecode_xmlapi(PyObject *self, PyObject *args, PyObject *keyw
         return pydata;
 }
 
-
-
-static PyObject *dmidecode_dump(PyObject * self, PyObject * null)
+static PyObject *dmidecode_dump(PyObject *self, PyObject *null)
 {
         const char *f;
         struct stat _buf;
+        int ret;
+        if (global_options->dumpfile == NULL)
+                Py_RETURN_FALSE;
 
         f = (global_options->dumpfile ? global_options->dumpfile : global_options->devmem);
         stat(f, &_buf);
 
-        if( (access(f, F_OK) != 0) || ((access(f, W_OK) == 0) && S_ISREG(_buf.st_mode)) ) {
-                if( dump(DEFAULT_MEM_DEV, f) ) {
+        if ((access(f, F_OK) != 0) || ((access(f, W_OK) == 0) && S_ISREG(_buf.st_mode)))
+        {
+                if (dump(SYS_TABLE_FILE, f))
+                {
                         Py_RETURN_TRUE;
                 }
         }
         Py_RETURN_FALSE;
 }
 
-static PyObject *dmidecode_get_dev(PyObject * self, PyObject * null)
+static PyObject *dmidecode_get_dev(PyObject *self, PyObject *null)
 {
         PyObject *dev = NULL;
         dev = PYTEXT_FROMSTRING((global_options->dumpfile != NULL
-                                   ? global_options->dumpfile : global_options->devmem));
+                                     ? global_options->dumpfile
+                                     : global_options->devmem));
         Py_INCREF(dev);
         return dev;
 }
 
-static PyObject *dmidecode_set_dev(PyObject * self, PyObject * arg)
+static PyObject *dmidecode_set_dev(PyObject *self, PyObject *arg)
 {
         char *f = NULL;
-        if(PyUnicode_Check(arg)) {
+        if (PyUnicode_Check(arg))
+        {
                 f = PyUnicode_AsUTF8(arg);
-        } else if(PyBytes_Check(arg)) {
+        }
+        else if (PyBytes_Check(arg))
+        {
                 f = PyBytes_AsString(arg);
         }
-        if(f) {
+        if (f)
+        {
                 struct stat buf;
 
-                if( (f != NULL) && (global_options->dumpfile != NULL )
-                    && (strcmp(global_options->dumpfile, f) == 0) ) {
+                if ((f != NULL) && (global_options->dumpfile != NULL) && (strcmp(global_options->dumpfile, f) == 0))
+                {
                         Py_RETURN_TRUE;
                 }
-                if( (f == NULL) || (strlen(f) < 0) ) {
+                if ((f == NULL) || (strlen(f) < 0))
+                {
                         PyReturnError(PyExc_RuntimeError, "set_dev() file name string cannot be empty");
                 }
-
                 errno = 0;
-                if( stat(f, &buf) < 0 ) {
-                        if( errno == ENOENT ) {
+                if (stat(f, &buf) < 0)
+                {
+                        if (errno == ENOENT)
+                        {
                                 // If this file does not exist, that's okay.
                                 // python-dmidecode will create it.
                                 global_options->dumpfile = strdup(f);
@@ -643,17 +943,25 @@ static PyObject *dmidecode_set_dev(PyObject * self, PyObject * arg)
                         }
                         PyReturnError(PyExc_RuntimeError, strerror(errno));
                 }
-                if(S_ISCHR(buf.st_mode)) {
-                        if(memcmp(f, "/dev/mem", 8) == 0) {
-                                if( global_options->dumpfile != NULL ) {
+
+                if (S_ISCHR(buf.st_mode))
+                {
+                        if (memcmp(f, "/dev/mem", 8) == 0)
+                        {
+                                if (global_options->dumpfile != NULL)
+                                {
                                         free(global_options->dumpfile);
                                         global_options->dumpfile = NULL;
                                 }
                                 Py_RETURN_TRUE;
-                        } else {
+                        }
+                        else
+                        {
                                 PyReturnError(PyExc_RuntimeError, "Invalid memory device: %s", f);
                         }
-                } else if(S_ISREG(buf.st_mode) || S_ISLNK(buf.st_mode) ) {
+                }
+                else if (S_ISREG(buf.st_mode) || S_ISLNK(buf.st_mode))
+                {
                         global_options->dumpfile = strdup(f);
                         Py_RETURN_TRUE;
                 }
@@ -661,132 +969,141 @@ static PyObject *dmidecode_set_dev(PyObject * self, PyObject * arg)
         PyReturnError(PyExc_RuntimeError, "set_dev(): Invalid input");
 }
 
-static PyObject *dmidecode_set_pythonxmlmap(PyObject * self, PyObject * arg)
+static PyObject *dmidecode_set_pythonxmlmap(PyObject *self, PyObject *arg)
 {
         char *fname = NULL;
 
-        if (PyUnicode_Check(arg)) {
+        if (PyUnicode_Check(arg))
+        {
                 fname = PyUnicode_AsUTF8(arg);
-        } else if (PyBytes_Check(arg)) {
+        }
+        else if (PyBytes_Check(arg))
+        {
                 fname = PyBytes_AsString(arg);
         }
-        if (fname) {
+        if (fname)
+        {
                 struct stat fileinfo;
 
                 memset(&fileinfo, 0, sizeof(struct stat));
-                if( stat(fname, &fileinfo) != 0 ) {
+                if (stat(fname, &fileinfo) != 0)
+                {
                         PyReturnError(PyExc_IOError, "Could not access the file '%s'", fname);
                 }
 
                 free(global_options->python_xml_map);
                 global_options->python_xml_map = strdup(fname);
                 Py_RETURN_TRUE;
-        } else {
+        }
+        else
+        {
                 Py_RETURN_FALSE;
         }
 }
 
-
-static PyObject * dmidecode_get_warnings(PyObject *self, PyObject *null)
+static PyObject *dmidecode_get_warnings(PyObject *self, PyObject *null)
 {
         char *warn = NULL;
         PyObject *ret = NULL;
 
         warn = log_retrieve(global_options->logdata, LOG_WARNING);
-        if( warn ) {
+        if (warn)
+        {
                 ret = PYTEXT_FROMSTRING(warn);
                 free(warn);
-        } else {
+        }
+        else
+        {
                 ret = Py_None;
         }
         return ret;
 }
 
-
-static PyObject * dmidecode_clear_warnings(PyObject *self, PyObject *null)
+static PyObject *dmidecode_clear_warnings(PyObject *self, PyObject *null)
 {
         log_clear_partial(global_options->logdata, LOG_WARNING, 1);
         Py_RETURN_TRUE;
 }
 
-
 static PyMethodDef DMIDataMethods[] = {
-        {(char *)"dump", dmidecode_dump, METH_NOARGS, (char *)"Dump dmidata to set file"},
-        {(char *)"get_dev", dmidecode_get_dev, METH_NOARGS,
-         (char *)"Get an alternative memory device file"},
-        {(char *)"set_dev", dmidecode_set_dev, METH_O,
-         (char *)"Set an alternative memory device file"},
+    {(char *)"dump", dmidecode_dump, METH_NOARGS, (char *)"Dump dmidata to set file"},
+    {(char *)"get_dev", dmidecode_get_dev, METH_NOARGS,
+     (char *)"Get an alternative memory device file"},
+    {(char *)"set_dev", dmidecode_set_dev, METH_O,
+     (char *)"Set an alternative memory device file"},
 
-        {(char *)"bios", dmidecode_get_bios, METH_VARARGS, (char *)"BIOS Data"},
-        {(char *)"system", dmidecode_get_system, METH_VARARGS, (char *)"System Data"},
-        {(char *)"baseboard", dmidecode_get_baseboard, METH_VARARGS, (char *)"Baseboard Data"},
-        {(char *)"chassis", dmidecode_get_chassis, METH_VARARGS, (char *)"Chassis Data"},
-        {(char *)"processor", dmidecode_get_processor, METH_VARARGS, (char *)"Processor Data"},
-        {(char *)"memory", dmidecode_get_memory, METH_VARARGS, (char *)"Memory Data"},
-        {(char *)"cache", dmidecode_get_cache, METH_VARARGS, (char *)"Cache Data"},
-        {(char *)"connector", dmidecode_get_connector, METH_VARARGS, (char *)"Connector Data"},
-        {(char *)"slot", dmidecode_get_slot, METH_VARARGS, (char *)"Slot Data"},
+    {(char *)"bios", dmidecode_get_bios, METH_VARARGS, (char *)"BIOS Data"},
+    {(char *)"system", dmidecode_get_system, METH_VARARGS, (char *)"System Data"},
+    {(char *)"baseboard", dmidecode_get_baseboard, METH_VARARGS, (char *)"Baseboard Data"},
+    {(char *)"chassis", dmidecode_get_chassis, METH_VARARGS, (char *)"Chassis Data"},
+    {(char *)"processor", dmidecode_get_processor, METH_VARARGS, (char *)"Processor Data"},
+    {(char *)"memory", dmidecode_get_memory, METH_VARARGS, (char *)"Memory Data"},
+    {(char *)"cache", dmidecode_get_cache, METH_VARARGS, (char *)"Cache Data"},
+    {(char *)"connector", dmidecode_get_connector, METH_VARARGS, (char *)"Connector Data"},
+    {(char *)"slot", dmidecode_get_slot, METH_VARARGS, (char *)"Slot Data"},
 
-        {(char *)"QuerySection", dmidecode_get_section, METH_O,
-         (char *) "Queries the DMI data structure for a given section name.  A section"
-         "can often contain several DMI type elements"
-        },
+    {(char *)"QuerySection", dmidecode_get_section, METH_O,
+     (char *)"Queries the DMI data structure for a given section name.  A section"
+             "can often contain several DMI type elements"},
 
-        {(char *)"type", dmidecode_get_type, METH_VARARGS, (char *)"By Type"},
+    {(char *)"type", dmidecode_get_type, METH_VARARGS, (char *)"By Type"},
 
-        {(char *)"QueryTypeId", dmidecode_get_type, METH_VARARGS,
-         (char *) "Queries the DMI data structure for a specific DMI type."
-        },
+    {(char *)"QueryTypeId", dmidecode_get_type, METH_VARARGS,
+     (char *)"Queries the DMI data structure for a specific DMI type."},
 
-        {(char *)"pythonmap", dmidecode_set_pythonxmlmap, METH_O,
-         (char *) "Use another python dict map definition. The default file is " PYTHON_XML_MAP},
+    {(char *)"pythonmap", dmidecode_set_pythonxmlmap, METH_O,
+     (char *)"Use another python dict map definition. The default file is " PYTHON_XML_MAP},
 
-        {(char *)"xmlapi", dmidecode_xmlapi, METH_VARARGS | METH_KEYWORDS,
-         (char *) "Internal API for retrieving data as raw XML data"},
+    {(char *)"xmlapi", dmidecode_xmlapi, METH_VARARGS | METH_KEYWORDS,
+     (char *)"Internal API for retrieving data as raw XML data"},
 
+    {(char *)"get_warnings", dmidecode_get_warnings, METH_NOARGS,
+     (char *)"Retrieve warnings from operations"},
 
-        {(char *)"get_warnings", dmidecode_get_warnings, METH_NOARGS,
-         (char *) "Retrieve warnings from operations"},
+    {(char *)"clear_warnings", dmidecode_clear_warnings, METH_NOARGS,
+     (char *)"Clear all warnings"},
 
-        {(char *)"clear_warnings", dmidecode_clear_warnings, METH_NOARGS,
-         (char *) "Clear all warnings"},
-
-        {NULL, NULL, 0, NULL}
-};
+    {NULL, NULL, 0, NULL}};
 
 void destruct_options(void *ptr)
 {
 #ifdef IS_PY3K
         ptr = PyCapsule_GetPointer(ptr, NULL);
 #endif
-        options *opt = (options *) ptr;
+        options *opt = (options *)ptr;
 
-        if( opt->mappingxml != NULL ) {
+        if (opt->mappingxml != NULL)
+        {
                 xmlFreeDoc(opt->mappingxml);
                 opt->mappingxml = NULL;
         }
 
-        if( opt->python_xml_map != NULL ) {
+        if (opt->python_xml_map != NULL)
+        {
                 free(opt->python_xml_map);
                 opt->python_xml_map = NULL;
         }
 
-        if( opt->dmiversion_n != NULL ) {
+        if (opt->dmiversion_n != NULL)
+        {
                 xmlFreeNode(opt->dmiversion_n);
                 opt->dmiversion_n = NULL;
         }
 
-        if( opt->dumpfile != NULL ) {
+        if (opt->dumpfile != NULL)
+        {
                 free(opt->dumpfile);
                 opt->dumpfile = NULL;
         }
 
-        if( opt->logdata != NULL ) {
+        if (opt->logdata != NULL)
+        {
                 char *warn = NULL;
 
                 log_clear_partial(opt->logdata, LOG_WARNING, 0);
                 warn = log_retrieve(opt->logdata, LOG_WARNING);
-                if( warn ) {
+                if (warn)
+                {
                         fprintf(stderr, "\n** COLLECTED WARNINGS **\n%s** END OF WARNINGS **\n\n", warn);
                         free(warn);
                 }
@@ -806,8 +1123,7 @@ static struct PyModuleDef dmidecodemod_def = {
     NULL,
     NULL,
     NULL,
-    NULL
-};
+    NULL};
 
 PyMODINIT_FUNC
 PyInit_dmidecodemod(void)
@@ -824,11 +1140,11 @@ initdmidecodemod(void)
         xmlInitParser();
         xmlXPathInit();
 
-        opt = (options *) malloc(sizeof(options)+2);
+        opt = (options *)malloc(sizeof(options) + 2);
         if (opt == NULL)
                 MODINITERROR;
 
-        memset(opt, 0, sizeof(options)+2);
+        memset(opt, 0, sizeof(options) + 2);
         init(opt);
 #ifdef IS_PY3K
         module = PyModule_Create(&dmidecodemod_def);
@@ -836,7 +1152,8 @@ initdmidecodemod(void)
         module = Py_InitModule3((char *)"dmidecodemod", DMIDataMethods,
                                 "Python extension module for dmidecode");
 #endif
-        if (module == NULL) {
+        if (module == NULL)
+        {
                 free(opt);
                 MODINITERROR;
         }
@@ -844,7 +1161,6 @@ initdmidecodemod(void)
         version = PYTEXT_FROMSTRING(VERSION);
         Py_INCREF(version);
         PyModule_AddObject(module, "version", version);
-
         opt->dmiversion_n = dmidecode_get_version(opt);
         dmiver = dmixml_GetContent(opt->dmiversion_n);
         PyModule_AddObject(module, "dmi", dmiver ? PYTEXT_FROMSTRING(dmiver) : Py_None);

--- a/src/dmidecodemodule.h
+++ b/src/dmidecodemodule.h
@@ -68,10 +68,10 @@ xmlNode *dmidecode_get_version(options *);
 extern void dmi_dump(xmlNode *node, struct dmi_header *h);
 extern int address_from_efi(Log_t *logp, size_t * address);
 extern void to_dmi_header(struct dmi_header *h, u8 * data);
-extern int smbios_decode(Log_t *logp, int type, u8 *buf, const char *devmem, xmlNode *node);
-extern int legacy_decode(Log_t *logp, int type, u8 *buf, const char *devmem, xmlNode *node);
+extern int smbios_decode(Log_t *logp, int type, u8 *buf, const char *devmem, u32 flags, xmlNode *node);
+extern int legacy_decode(Log_t *logp, int type, u8 *buf, const char *devmem, u32 flags, xmlNode *node);
 extern xmlNode *smbios_decode_get_version(u8 * buf, const char *devmem);
 extern xmlNode *legacy_decode_get_version(u8 * buf, const char *devmem);
-extern void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem);
+extern void *mem_chunk(Log_t *logp, off_t base, size_t len, const char *devmem);
 
 PyMODINIT_FUNC initdmidecode(void);

--- a/src/dmidump.c
+++ b/src/dmidump.c
@@ -37,6 +37,13 @@
 #include "dmidump.h"
 #include "efi.h"
 
+#define FLAG_NO_FILE_OFFSET     (1 << 0)
+#define FLAG_STOP_AT_EOT        (1 << 1)
+
+#define SYS_FIRMWARE_DIR "/sys/firmware/dmi/tables"
+#define SYS_ENTRY_FILE SYS_FIRMWARE_DIR "/smbios_entry_point"
+#define SYS_TABLE_FILE SYS_FIRMWARE_DIR "/DMI"
+
 /*
  * Build a crafted entry point with table address hard-coded to 32,
  * as this is where we will put it in the output file. We adjust the
@@ -51,146 +58,216 @@ static void overwrite_dmi_address(u8 * buf)
         buf[0x0B] = 0;
 }
 
-
-int write_dump(size_t base, size_t len, const void *data, const char *dumpfile, int add)
+/* Same thing for SMBIOS3 entry points */
+static void overwrite_smbios3_address(u8 *buf)
 {
-        FILE *f;
-
-        f = fopen(dumpfile, add ? "r+b" : "wb");
-        if(!f) {
-                fprintf(stderr, "%s: ", dumpfile);
-                perror("fopen");
-                return -1;
-        }
-
-        if(fseek(f, base, SEEK_SET) != 0) {
-                fprintf(stderr, "%s: ", dumpfile);
-                perror("fseek");
-                goto err_close;
-        }
-
-        if(fwrite(data, len, 1, f) != 1) {
-                fprintf(stderr, "%s: ", dumpfile);
-                perror("fwrite");
-                goto err_close;
-        }
-
-        if(fclose(f)) {
-                fprintf(stderr, "%s: ", dumpfile);
-                perror("fclose");
-                return -1;
-        }
-
-        return 0;
-
-      err_close:
-        fclose(f);
-        return -1;
+        buf[0x05] += buf[0x10] + buf[0x11] + buf[0x12] + buf[0x13]
+                        + buf[0x14] + buf[0x15] + buf[0x16] + buf[0x17] - 32;
+        buf[0x10] = 32;
+        buf[0x11] = 0;
+        buf[0x12] = 0;
+        buf[0x13] = 0;
+        buf[0x14] = 0;
+        buf[0x15] = 0;
+        buf[0x16] = 0;
+        buf[0x17] = 0;
 }
 
-
-int dumpling(u8 * buf, const char *dumpfile, u8 mode)
+void dmi_table_dump(const u8 *buf, u32 len, const char *dumpfile)
 {
-        u32 base;
-        u16 len;
+	write_dump(32, len, buf, dumpfile, 0);
+}
 
-        if(mode == NON_LEGACY) {
-                if(!checksum(buf, buf[0x05]) || !memcmp(buf + 0x10, "_DMI_", 5) == 0 ||
-                   !checksum(buf + 0x10, 0x0F))
-                        return 0;
-                base = DWORD(buf + 0x18);
-                len = WORD(buf + 0x16);
-        } else {
-                if(!checksum(buf, 0x0F))
-                        return 0;
-                base = DWORD(buf + 0x08);
-                len = WORD(buf + 0x06);
-        }
+void dmi_table(off_t base, u32 len, u16 num, u32 ver, const char *devmem,
+                      u32 flags, const char *dumpfile)
+{
+	u8 *buf;
+	size_t size = len;
 
-        u8 *buff;
+	buf = read_file(NULL, flags & FLAG_NO_FILE_OFFSET ? 0 : base,
+                        &size, devmem);
+	len = size;
 
-        if((buff = mem_chunk(NULL, base, len, DEFAULT_MEM_DEV)) != NULL) {
-                //. Part 1.
-#ifdef NDEBUG
-                printf("# Writing %d bytes to %s.\n", len, dumpfile);
-#endif
-                write_dump(32, len, buff, dumpfile, 0);
-                free(buff);
+	if (buf == NULL)
+	{
+		printf("read failed\n");
+	}
+	dmi_table_dump(buf, len, dumpfile);
+	free(buf);
+}
 
-                //. Part 2.
-                if(mode != LEGACY) {
-                        u8 crafted[32];
+static int smbios3_decode(u8 *buf, const char *devmem, u32 flags, const char *dumpfile)
+{
+        u32 ver;
+        u64 offset;
+	offset = QWORD(buf + 0x10);
+	ver = (buf[0x07] << 16) + (buf[0x08] << 8) + buf[0x09];
 
-                        memcpy(crafted, buf, 32);
-                        overwrite_dmi_address(crafted + 0x10);
-#ifdef NDEBUG
-                        printf("# Writing %d bytes to %s.\n", crafted[0x05], dumpfile);
-#endif
-                        write_dump(0, crafted[0x05], crafted, dumpfile, 1);
-                } else {
-                        u8 crafted[16];
+        dmi_table(((off_t)offset.h << 32) | offset.l,DWORD(buf + 0x0C), 0, ver, devmem, flags | FLAG_STOP_AT_EOT, dumpfile);
 
-                        memcpy(crafted, buf, 16);
-                        overwrite_dmi_address(crafted);
-#ifdef NDEBUG
-                        printf("# Writing %d bytes to %s.\n", 0x0F, dumpfile);
-#endif
-                        write_dump(0, 0x0F, crafted, dumpfile, 1);
-                }
-        } else {
-                fprintf(stderr, "Failed to read table, sorry.\n");
-        }
+        if (!checksum(buf, buf[0x05]))
+                return 0;
 
-        //. TODO: Cleanup
-        return 1;
+        u8 crafted[32];
+        memcpy(crafted, buf, 32);
+        overwrite_smbios3_address(crafted);
+        //overwrite_dmi_address(crafted);
+	//printf("Writing %d bytes to %s.",crafted[0x06], dumpfile);
+        write_dump(0, crafted[0x06], crafted, dumpfile, 1);
+	return 1;
+}
+
+static int smbios_decode(u8 *buf, const char *devmem, u32 flags, const char *dumpfile)
+{
+	u16 ver;
+        if (!checksum(buf, buf[0x05])
+         || memcmp(buf + 0x10, "_DMI_", 5) != 0
+         || !checksum(buf + 0x10, 0x0F))
+                return 0;
+
+        ver = (buf[0x06] << 8) + buf[0x07];
+	switch (ver)
+	{
+		case 0x021F:
+		case 0x0221:
+			ver = 0x0203;
+			break;
+		case 0x0233:
+			ver = 0x0206;
+			break;
+	}
+
+
+        dmi_table(DWORD(buf + 0x18), WORD(buf + 0x16), WORD(buf + 0x1C), 
+                ver << 8, devmem, flags, dumpfile);
+
+        u8 crafted[32];
+        memcpy(crafted, buf, 32);
+        overwrite_dmi_address(crafted + 0x10);
+        write_dump(0, crafted[0x05], crafted, dumpfile, 1);
+
+	return 1;
+}
+
+static int legacy_decode(u8 *buf, const char *devmem, u32 flags,  const char *dumpfile)
+{
+        u8 crafted[16];
+
+        //dmi_table();
+        dmi_table(DWORD(buf + 0x08), WORD(buf + 0x06), WORD(buf + 0x0C),
+                ((buf[0x0E] & 0xF0) << 12) + ((buf[0x0E] & 0x0F) << 8),
+                devmem, flags, dumpfile);
+
+        memcpy(crafted, buf, 16);
+        overwrite_smbios3_address(crafted);
+        write_dump(0, 0x0F, crafted, dumpfile, 1);
 }
 
 
 int dump(const char *memdev, const char *dumpfile)
 {
-        /* On success, return found, otherwise return -1 */
+        /* On success, return found, otherwise return 0 */
         int ret = 0;
         int found = 0;
         size_t fp;
         int efi;
         u8 *buf;
+        size_t size;
+
+	/*
+         * First try reading from sysfs tables.  The entry point file could
+         * contain one of several types of entry points, so read enough for
+         * the largest one, then determine what type it contains.
+         */
+        size = 0x20;
+        if ( (buf = read_file(NULL, 0, &size, SYS_ENTRY_FILE)) != NULL){
+                if (size >= 24 && memcmp(buf, "_SM3_", 5) == 0){
+                        if (smbios3_decode(buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET, dumpfile))
+                                found++;
+                } else if (size >= 31 && memcmp(buf, "_SM_", 4) == 0) {
+                        if (smbios_decode(buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET, dumpfile))
+                                found++;
+                } else if (size >= 15 && memcmp(buf, "_DMI_", 5) == 0){
+                        if (legacy_decode(buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET, dumpfile))
+                                found++;
+                }
+		if (found){
+			ret = 1;
+			goto exit_free;
+		}
+        }
 
         /* First try EFI (ia64, Intel-based Mac) */
         efi = address_from_efi(NULL, &fp);
-        if(efi == EFI_NOT_FOUND) {
-                /* Fallback to memory scan (x86, x86_64) */
-                if((buf = mem_chunk(NULL, 0xF0000, 0x10000, memdev)) != NULL) {
-                        for(fp = 0; fp <= 0xFFF0; fp += 16) {
-                                if(memcmp(buf + fp, "_SM_", 4) == 0 && fp <= 0xFFE0) {
-                                        if(dumpling(buf + fp, dumpfile, NON_LEGACY))
-                                                found++;
-                                        fp += 16;
-                                } else if(memcmp(buf + fp, "_DMI_", 5) == 0) {
-                                        if(dumpling(buf + fp, dumpfile, LEGACY))
-                                                found++;
-                                }
+	switch(efi)
+	{
+		case EFI_NOT_FOUND:
+			goto memory_scan;
+		case EFI_NO_SMBIOS:
+			ret = 1;
+			goto exit_free;
+	}
+
+	if ((buf = mem_chunk(NULL, fp, 0x20, memdev )) == NULL){
+		ret = 1;
+		goto exit_free;
+	}
+
+	if (memcmp(buf, "_SM3_", 5) == 0){
+		if(smbios3_decode(buf, memdev, 0, dumpfile))
+			found++;
+	} else if (memcmp(buf, "_SM_", 4) == 0){
+		if(smbios_decode(buf, memdev, 0, dumpfile))
+			found++;
+	}
+	goto done;
+
+memory_scan:
+#if defined __i386__ || defined __x86_64__
+        /* Fallback to memory scan (x86, x86_64) */
+        if((buf = mem_chunk(NULL, 0xF0000, 0x10000, memdev)) == NULL) {
+		ret = 1;
+		goto exit_free;
+	}
+
+	/* Look for a 64-bit entry point first */
+        for(fp = 0; fp <= 0xFFF0; fp += 16){
+                if(memcmp(buf + fp, "_SM3_", 5) == 0 && fp <= 0xFFE0){
+                        if(smbios3_decode(buf + fp, memdev, 0, dumpfile)){
+                                found++;
+                                goto done;
                         }
-                } else
-                        ret = -1;
-        } else if(efi == EFI_NO_SMBIOS) {
-                ret = -1;
-        } else {
-                if((buf = mem_chunk(NULL, fp, 0x20, memdev)) == NULL)
-                        ret = -1;
-                else if(dumpling(buf, dumpfile, NON_LEGACY))
-                        found++;
+		}
         }
 
-        if(ret == 0) {
-                free(buf);
-                if(!found) {
-                        ret = -1;
-                }
-        }
+	/* If none found, look for a 32-bit entry point */
+        for(fp = 0; fp <= 0xFFF0; fp += 16) {
+        	if(memcmp(buf + fp, "_SM_", 4) == 0 && fp <= 0xFFE0) {
+			if(smbios_decode(buf + fp, memdev, 0, dumpfile)){
+				found++;
+				goto done;
+			}
+		} else if (memcmp(buf+fp, "_DMI_", 5) == 0){
+			if(legacy_decode(buf+fp, memdev, 0, dumpfile)){
+				found++;
+				goto done;
+			}
+		}
+	}
+#endif
 
-        return ret == 0 ? found : ret;
+done:
+	if(!found){
+		printf("No SMBIOS nor DMI entry point found, sorry.\n");
+	}
+	free(buf);
+
+exit_free:
+	if (!found)
+		free(buf);
+
+	return ret;
 }
-
 
 #ifdef _DMIDUMP_MAIN_
 int main(int argc, char **argv)
@@ -204,3 +281,4 @@ int main(int argc, char **argv)
         return 0;
 }
 #endif
+

--- a/src/efi.c
+++ b/src/efi.c
@@ -44,11 +44,13 @@
  * @param size_t*
  * @return returns EFI_NOT_FOUND or EFI_NO_SMBIOS
  */
+
 int address_from_efi(Log_t *logp, size_t * address)
 {
         FILE *efi_systab;
         const char *filename = NULL;
         char linebuf[64];
+	const char *eptype;
         int ret;
 
         *address = 0;           /* Prevent compiler warning */
@@ -58,17 +60,18 @@ int address_from_efi(Log_t *logp, size_t * address)
          ** Linux >= 2.6.7: /sys/firmware/efi/systab
          */
         if((efi_systab = fopen(filename = "/sys/firmware/efi/systab", "r")) == NULL
-           && (efi_systab = fopen(filename = "/proc/efi/systab", "r")) == NULL) {
+        && (efi_systab = fopen(filename = "/proc/efi/systab", "r")) == NULL) {
                 /* No EFI interface, fallback to memory scan */
                 return EFI_NOT_FOUND;
         }
         ret = EFI_NO_SMBIOS;
         while((fgets(linebuf, sizeof(linebuf) - 1, efi_systab)) != NULL) {
                 char *addrp = strchr(linebuf, '=');
-
                 *(addrp++) = '\0';
-                if(strcmp(linebuf, "SMBIOS") == 0) {
+                if(strcmp(linebuf, "SMBIOS3") == 0
+		|| strcmp(linebuf, "SMBIOS") == 0) {
                         *address = strtoul(addrp, NULL, 0);
+			eptype = linebuf;
                         ret = 0;
                         break;
                 }

--- a/src/util.c
+++ b/src/util.c
@@ -50,16 +50,17 @@
 #include "util.h"
 #include "dmilog.h"
 
-#ifndef USE_MMAP
 static int myread(Log_t *logp, int fd, u8 * buf, size_t count, const char *prefix)
 {
         ssize_t r = 1;
         size_t r2 = 0;
-
-        while(r2 != count && r != 0) {
+        while(r2 != count && r != 0) 
+	{
                 r = read(fd, buf + r2, count - r2);
-                if(r == -1) {
-                        if(errno != EINTR) {
+                if(r == -1) 
+		{
+                        if(errno != EINTR) 
+			{
                                 close(fd);
                                 perror(prefix);
                                 return -1;
@@ -68,7 +69,8 @@ static int myread(Log_t *logp, int fd, u8 * buf, size_t count, const char *prefi
                         r2 += r;
         }
 
-        if(r2 != count) {
+        if(r2 != count) 
+	{
                 close(fd);
                 log_append(logp, LOGFL_NORMAL, LOG_WARNING, "%s: Unexpected end of file", prefix);
                 return -1;
@@ -76,7 +78,6 @@ static int myread(Log_t *logp, int fd, u8 * buf, size_t count, const char *prefi
 
         return 0;
 }
-#endif
 
 int checksum(const u8 * buf, size_t len)
 {
@@ -87,6 +88,74 @@ int checksum(const u8 * buf, size_t len)
                 sum += buf[a];
         return (sum == 0);
 }
+
+/*
+ * Reads all of file from given offset, up to max_len bytes.
+ * A buffer of at most max_len bytes is allocated by this function, and
+ * needs to be freed by the caller.
+ * This provides a similar usage model to mem_chunk()
+ *
+ * Returns a pointer to the allocated buffer, or NULL on error, and
+ * sets max_len to the length actually read.
+ */
+void *read_file(Log_t *logp, off_t base, size_t *max_len, const char *filename)
+{
+        struct stat statbuf;
+        int fd;
+        u8 *p;
+        /*
+         * Don't print error message on missing file, as we will try to read
+         * files that may or may not be present.
+         */
+        if ((fd = open(filename, O_RDONLY)) == -1)
+        {
+                if (errno != ENOENT)
+                        perror(filename);
+                return NULL;
+        }
+
+        /*
+         * Check file size, don't allocate more than can be read.
+         */
+        if (fstat(fd, &statbuf) == 0)
+        {
+                if (base >= statbuf.st_size)
+                {
+                        fprintf(stderr, "%s: Can't read data beyond EOF\n",
+                                filename);
+                        p = NULL;
+                        goto out;
+                }
+                if (*max_len > (size_t)statbuf.st_size - base)
+                        *max_len = statbuf.st_size - base;
+        }
+
+        if ((p = malloc(*max_len)) == NULL)
+        {
+                perror("malloc");
+                goto out;
+        }
+
+        if (lseek(fd, base, SEEK_SET) == -1)
+        {
+                fprintf(stderr, "%s: ", filename);
+                perror("lseek");
+                goto err_free;
+        }
+        if (myread(logp, fd, p, *max_len, filename) == 0)
+                goto out;
+
+err_free:
+        free(p);
+        p = NULL;
+
+out:
+        if (close(fd) == -1)
+                perror(filename);
+
+        return p;
+}
+
 
 /* Static global variables which should only
  * be used by the sigill_handler()
@@ -105,35 +174,68 @@ void sigill_handler(int ignore_this) {
         }
 }
 
+static void safe_memcpy(void *dest, const void *src, size_t n)
+{
+#ifdef USE_SLOW_MEMCPY
+        size_t i;
+
+        for (i = 0; i < n; i++)
+                *((u8 *)dest + i) = *((const u8 *)src + i);
+#else
+        memcpy(dest, src, n);
+#endif
+}
+
 /*
  * Copy a physical memory chunk into a memory buffer.
  * This function allocates memory.
  */
-void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
+void *mem_chunk(Log_t *logp, off_t base, size_t len, const char *devmem)
 {
         void *p;
         int fd = -1;
 
 #ifdef USE_MMAP
+	struct stat statbuf;
         size_t mmoffset;
         void *mmp;
 #endif
         sigill_logobj = logp;
-        signal(SIGILL, sigill_handler);
+
+	signal(SIGILL, sigill_handler);
+
         if(sigill_error || (fd = open(devmem, O_RDONLY)) == -1) {
                 log_append(logp, LOGFL_NORMAL, LOG_WARNING,
                            "Failed to open memory buffer (%s): %s",
                            devmem, strerror(errno));
-                p = NULL;
-                goto exit;
+		p = NULL;
+                return p;
         }
 
         if(sigill_error || (p = malloc(len)) == NULL) {
                 log_append(logp, LOGFL_NORMAL, LOG_WARNING,"malloc: %s", strerror(errno));
                 p = NULL;
-                goto exit;
+                return p;
         }
 #ifdef USE_MMAP
+	if (sigill_error || fstat(fd, &statbuf) == -1 )
+	{
+		log_append(logp, LOGFL_NORMAL, LOG_WARNING,"fstat: %s", strerror(errno));
+		goto err_free;
+	}
+
+        /*
+         * mmap() will fail with SIGBUS if trying to map beyond the end of
+         * the file.
+         */
+	if (sigill_error ||  S_ISREG(statbuf.st_mode) && base + (off_t)len > statbuf.st_size )
+	{
+		log_append(logp, LOGFL_NORMAL, LOG_WARNING,
+				"mmap: Can't map beyond end of file %s: %s", 
+				devmem, strerror(errno));
+		goto err_free;
+	}
+
 #ifdef _SC_PAGESIZE
         mmoffset = base % sysconf(_SC_PAGESIZE);
 #else
@@ -144,15 +246,18 @@ void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
          * but to workaround problems many people encountered when trying
          * to read from /dev/mem using regular read() calls.
          */
-        mmp = mmap(0, mmoffset + len, PROT_READ, MAP_SHARED, fd, base - mmoffset);
+        mmp = mmap(NULL, mmoffset + len, PROT_READ, MAP_SHARED, fd, base - mmoffset);
+	
         if(sigill_error || (mmp == MAP_FAILED)) {
                 log_append(logp, LOGFL_NORMAL, LOG_WARNING, "%s (mmap): %s", devmem, strerror(errno));
-                free(p);
-                p = NULL;
-                goto exit;
+		goto try_read;
+                // free(p);
+                // p = NULL;
+                // goto exit;
         }
 
-        memcpy(p, (u8 *) mmp + mmoffset, len);
+        safe_memcpy(p, (u8 *) mmp + mmoffset, len);
+	
         if (sigill_error) {
                 log_append(logp, LOGFL_NODUPS, LOG_WARNING,
                            "Failed to do memcpy() due to SIGILL signal");
@@ -167,20 +272,25 @@ void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
                 p = NULL;
                 goto exit;
         }
-#else /* USE_MMAP */
-        if(sigill_error || (lseek(fd, base, SEEK_SET) == -1)) {
-                log_append(logp, LOGFL_NORMAL, LOG_WARNING, "%s (lseek): %s", devmem, strerror(errno));
+	goto exit;
+
+ try_read:
+#endif /* USE_MMAP */
+	if (lseek(fd, base, SEEK_SET) == -1 )
+	{
+		log_append(logp, LOGFL_NORMAL, LOG_WARNING, "%s (lseek): %s", devmem, strerror(errno));
+		goto err_free;
+	}
+
+	if(sigill_error || (myread(logp, fd, p, len, devmem) == 0)) {
                 free(p);
                 p = NULL;
                 goto exit;
         }
 
-        if(sigill_error || (myread(logp, fd, p, len, devmem) == -1)) {
-                free(p);
-                p = NULL;
-                goto exit;
-        }
-#endif /* USE_MMAP */
+ err_free:
+	free(p);
+	p = NULL;
 
  exit:
         if (fd >= 0) {
@@ -189,6 +299,7 @@ void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
         }
         signal(SIGILL, SIG_DFL);
         sigill_logobj = NULL;
+
         return p;
 }
 
@@ -207,3 +318,43 @@ u64 u64_range(u64 start, u64 end)
 
 	return res;
 }
+
+int write_dump(size_t base, size_t len, const void *data, const char *dumpfile, int add)
+{
+        FILE *f;
+	f = fopen(dumpfile, add ? "r+b" : "wb");
+        if (!f)
+        {
+                fprintf(stderr, "%s: ", dumpfile);
+                perror("fopen");
+                return -1;
+        }
+
+        if (fseek(f, base, SEEK_SET) != 0)
+        {
+                fprintf(stderr, "%s: ", dumpfile);
+                perror("fseek");
+                goto err_close;
+        }
+
+        if (fwrite(data, len, 1, f) != 1)
+        {
+                fprintf(stderr, "%s: ", dumpfile);
+                perror("fwrite");
+                goto err_close;
+        }
+
+        if (fclose(f))
+        {
+                fprintf(stderr, "%s: ", dumpfile);
+                perror("fclose");
+                return -1;
+        }
+
+        return 0;
+
+err_close:
+        fclose(f);
+        return -1;
+}
+

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,7 @@
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
 
 int checksum(const u8 * buf, size_t len);
-void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem);
+void *read_file( Log_t *logp, off_t base, size_t *len, const char *filename);
+void *mem_chunk(Log_t *logp, off_t base, size_t len, const char *devmem);
 int write_dump(size_t base, size_t len, const void *data, const char *dumpfile, int add);
 u64 u64_range(u64 start, u64 end);


### PR DESCRIPTION
Default use /dev/mem dump dmidecode info.
Add collecting info method from DMI instead /dev/mem.
Issue address:https://github.com/nima/python-dmidecode/issues/15