### PR TITLE
fix gcc compiling warning info for Smbios 3.3.0

### DIFF
--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -5245,7 +5245,7 @@ xmlNode *dmi_decode(xmlNode *prnt_n, dmi_codes_major *dmiMajor, struct dmi_heade
                 dmixml_AddAttribute(sect_n, "Databuswidth", "%i", data[0x11]);
 
                 if( h->length - 0x13 >= data[0x12] * 5)
-                        dmi_slot_peers(sect_n, data[0x12], h, data+0x13);
+                        dmi_slot_peers(sect_n, data[0x12], data+0x13, h);
                 break;
 
         case 10:               /* 7.11 On Board Devices Information */

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -4443,7 +4443,7 @@ void dmi_parse_protocol_record(xmlNode *node, u8 *rec)
         u8 assign_val;
         u8 addrtype;
         u8 hlen;
-        const char *addrstr;
+        // const char *addrstr;
         const char *hname;
         char attr[38];
 

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -6029,7 +6029,7 @@ xmlNode *dmi_decode(xmlNode *prnt_n, dmi_codes_major *dmiMajor, struct dmi_heade
                 if (h->length < 0x1B){
                         break;
                 }
-                dmi_tpm_vendor_id(sect_n, data[0x04]);
+                dmi_tpm_vendor_id(sect_n, data + 0x04);
                 switch (data[0x08]) {
                 case 0x01:
                         /*

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -6271,7 +6271,7 @@ xmlNode *smbios3_decode_get_version(u8 * buf, const char *devmem)
         dmixml_AddAttribute(data_n, "type", "SMBIOS");
 
         if(check == 1) {
-                u32 ver = (buf[0x07] << 16) + (buf[0x08] << 8) + buf[0x09];
+                // u32 ver = (buf[0x07] << 16) + (buf[0x08] << 8) + buf[0x09];
                 dmixml_AddTextContent(data_n, "SMBIOS %i.%i.%i present", buf[0x07], buf[0x08], buf[0x09]);
                 dmixml_AddAttribute(data_n, "version", "%i.%i.%i", buf[0x07], buf[0x08],buf[0x09]);
         } else if(check == 0) {

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -4785,7 +4785,6 @@ void dmi_tpm_characteristics(xmlNode *node, u64 code)
          */
         if (code.l & (1 << 2)) {
                 dmixml_AddTextContent(data_n, "%s", characteristics[0]);
-                return data_n;
         }
 
         for (i = 3; i <= 5; i++)

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -4259,7 +4259,7 @@ void dmi_additional_info(xmlNode *node, const struct dmi_header *h)
         assert( node != NULL );
 
         for(i = 0; i < count; i++) {
-                xmlNode *data_n = NULL, *str_n = NULL, *val_n = NULL;
+                xmlNode *data_n = NULL, *val_n = NULL;
 
                 /* Check for short entries */
                 if(h->length < offset + 1) {
@@ -4277,7 +4277,7 @@ void dmi_additional_info(xmlNode *node, const struct dmi_header *h)
                 dmixml_AddAttribute(data_n, "ReferenceHandle", "0x%04x", WORD(p + 0x01));
                 dmixml_AddAttribute(data_n, "ReferenceOffset", "0x%02x", p[0x03]);
 
-                str_n = dmixml_AddDMIstring(data_n, "String", h, p[0x04]);
+                dmixml_AddDMIstring(data_n, "String", h, p[0x04]);
 
                 switch (length - 0x05) {
                 case 1:

--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -4445,7 +4445,7 @@ void dmi_parse_protocol_record(xmlNode *node, u8 *rec)
         u8 hlen;
         // const char *addrstr;
         const char *hname;
-        char attr[38];
+        // char attr[38];
 
         /* DSP0270: 8.5: Protocol Identifier */
         rid = rec[0x0];

--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -144,22 +144,24 @@ xmlNode *dmidecode_get_version(options *opt)
         if(opt->dumpfile != NULL) {
                 //. printf("Reading SMBIOS/DMI data from file %s.\n", dumpfile);
                 if((buf = mem_chunk(opt->logdata, 0, 0x20, opt->dumpfile)) != NULL) {
-			ver_n = NULL;
-			goto exit_free;
-		}
-		if(memcmp(buf, "_SM3_", 5) == 0){
-			ver_n = smbios3_decode_get_version(buf, opt->dumpfile);
-			if ( dmixml_GetAttrValue(ver_n, "unknown") == NULL )
-				found++;
-		} else if(memcmp(buf, "_SM_", 4) == 0) {
-                        ver_n = smbios_decode_get_version(buf, opt->dumpfile);
-                        if( dmixml_GetAttrValue(ver_n, "unknown") == NULL )
-                                found++;
-                } else if(memcmp(buf, "_DMI_", 5) == 0) {
-                        ver_n = legacy_decode_get_version(buf, opt->dumpfile);
-                        if( dmixml_GetAttrValue(ver_n, "unknown") == NULL ) 
-                                found++;
+                        if (memcmp(buf, "_SM3_", 5) == 0) {
+                                ver_n = smbios3_decode_get_version(buf, opt->dumpfile);
+                                if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                                        found++;
+                        } else if (memcmp(buf, "_SM_", 4) == 0) {
+                                ver_n = smbios_decode_get_version(buf, opt->dumpfile);
+                                if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                                        found++;
+                        } else if (memcmp(buf, "_DMI_", 5) == 0) {
+                                ver_n = legacy_decode_get_version(buf, opt->dumpfile);
+                                if (dmixml_GetAttrValue(ver_n, "unknown") == NULL)
+                                        found++;
+                        }
+                } else {
+                        ver_n = NULL;
+                        goto exit_free;
                 }
+
         }
 
         /*

--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -392,9 +392,10 @@ memory_scan:
                         }
                 } else if(memcmp(buf + fp, "_DMI_", 5) == 0) {
                         if(legacy_decode(opt->logdata, opt->type,
-                                buf + fp, opt->devmem, 0, dmixml_n))
+                                buf + fp, opt->devmem, 0, dmixml_n)) {
                                 found++;
                                 goto done;
+                                }
                         }
                 }
 #endif

--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -203,7 +203,7 @@ xmlNode *dmidecode_get_version(options *opt)
 			goto exit_free;
 	}
 
-	if(buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem) == NULL){
+	if((buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem)) == NULL){
 		ver_n = NULL;
 		goto exit_free;
 	}

--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -347,7 +347,7 @@ int dmidecode_get_xml(options *opt, xmlNode* dmixml_n)
 			goto exit_free;
 	}
 
-	if(buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem) == NULL ){
+	if((buf = mem_chunk(opt->logdata, fp, 0x20, opt->devmem)) == NULL ){
 		ret = 1;
 		goto exit_free;
 	}

--- a/src/dmidump.c
+++ b/src/dmidump.c
@@ -154,6 +154,8 @@ static int legacy_decode(u8 *buf, const char *devmem, u32 flags,  const char *du
         memcpy(crafted, buf, 16);
         overwrite_smbios3_address(crafted);
         write_dump(0, 0x0F, crafted, dumpfile, 1);
+
+        return 1;
 }
 
 int dump(const char *memdev, const char *dumpfile)

--- a/src/efi.c
+++ b/src/efi.c
@@ -83,6 +83,10 @@ int address_from_efi(Log_t *logp, size_t * address)
                 log_append(logp, LOGFL_NODUPS, LOG_WARNING, "%s: SMBIOS entry point missing", filename);
         }
 
+        if(ret == 0){
+                log_append(logp, LOGFL_NODUPS, LOG_WARNING, "%s: entry point at 0x%08llx", eptype, (unsigned long long)*address);
+        }
+
         return ret;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -222,7 +222,7 @@ void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
          * mmap() will fail with SIGBUS if trying to map beyond the end of
          * the file.
          */
-        if (sigill_error ||  S_ISREG(statbuf.st_mode) && base + (off_t)len > statbuf.st_size )
+        if (sigill_error ||  S_ISREG(statbuf.st_mode) && (__off_t)(base + (off_t)len) > statbuf.st_size )
         {
                 log_append(logp, LOGFL_NORMAL, LOG_WARNING,
                                 "mmap: Can't map beyond end of file %s: %s",

--- a/src/util.c
+++ b/src/util.c
@@ -222,7 +222,7 @@ void *mem_chunk(Log_t *logp, size_t base, size_t len, const char *devmem)
          * mmap() will fail with SIGBUS if trying to map beyond the end of
          * the file.
          */
-        if (sigill_error ||  S_ISREG(statbuf.st_mode) && (__off_t)(base + (off_t)len) > statbuf.st_size )
+        if ((sigill_error || S_ISREG(statbuf.st_mode)) && (__off_t)(base + (off_t)len) > statbuf.st_size )
         {
                 log_append(logp, LOGFL_NORMAL, LOG_WARNING,
                                 "mmap: Can't map beyond end of file %s: %s",


### PR DESCRIPTION
Hi , Everyone,
    I have fixed the gcc warning problems in my code, and trying to solve warnings old code has. These fix warning patch also adjust some codes. Most warning caused by variables in dmidecode not used in python-dmidecode may cause warning.  I have fixed them after testing to make sure them will not cause bad influence.
    @lian-bo @lichliu , please test these patches if nesscery.