### PR TITLE
Solve issue 33 and pymap.xml missing chunk.

### DIFF
--- a/src/dmidecode.c
+++ b/src/dmidecode.c
@@ -5378,7 +5378,7 @@ xmlNode *dmi_decode(xmlNode *prnt_n, dmi_codes_major *dmiMajor, struct dmi_heade
                 dmi_memory_device_width(sect_n, "TotalWidth", WORD(data + 0x08));
                 dmi_memory_device_width(sect_n, "DataWidth", WORD(data + 0x0A));
                 if (h->length >= 0x20 && WORD(data + 0x0C) == 0x7FFF) {
-                        dmi_memory_device_extended_size(sect_n, WORD(data + 0x1C));
+                        dmi_memory_device_extended_size(sect_n, DWORD(data + 0x1C));
                 } else {
                         dmi_memory_device_size(sect_n, WORD(data + 0x0C));
                 }

--- a/src/pymap.xml
+++ b/src/pymap.xml
@@ -304,6 +304,7 @@
           <Map keytype="constant" key="SlotId"            valuetype="string" value="SlotID/@id"/>
           <Map keytype="constant" key="Type:SlotBusWidth" valuetype="string" value="SlotWidth"/>
           <Map keytype="constant" key="Type:SlotType"     valuetype="string" value="SlotType"/>
+	  <Map keytype="constant" key="Bus Address"       valuetype="string" value="BusAddress"/>
         </Map>
       </Map>
     </TypeMap>

--- a/src/types.h
+++ b/src/types.h
@@ -57,7 +57,7 @@ typedef struct {
 } u64;
 #endif
 
-#ifdef ALIGNMENT_WORKAROUND
+#if defined(ALIGNMENT_WORKAROUND) || defined(BIGENDIAN)
 static inline u64 U64(u32 low, u32 high)
 {
         u64 self;

--- a/src/types.h
+++ b/src/types.h
@@ -69,20 +69,18 @@ static inline u64 U64(u32 low, u32 high)
 }
 #endif
 
-#ifdef ALIGNMENT_WORKAROUND
-#	ifdef BIGENDIAN
-#	define WORD(x) (u16)((x)[1]+((x)[0]<<8))
-#	define DWORD(x) (u32)((x)[3]+((x)[2]<<8)+((x)[1]<<16)+((x)[0]<<24))
-#	define QWORD(x) (U64(DWORD(x+4), DWORD(x)))
-#	else /* BIGENDIAN */
-#	define WORD(x) (u16)((x)[0]+((x)[1]<<8))
-#	define DWORD(x) (u32)((x)[0]+((x)[1]<<8)+((x)[2]<<16)+((x)[3]<<24))
-#	define QWORD(x) (U64(DWORD(x), DWORD(x+4)))
-#	endif /* BIGENDIAN */
-#else /* ALIGNMENT_WORKAROUND */
+/*
+ * Per SMBIOS v2.8.0 and later, all structures assume a little-endian
+ * ordering convention.
+ */
+#if defined(ALIGNMENT_WORKAROUND) || defined(BIGENDIAN)
+#define WORD(x) (u16)((x)[0] + ((x)[1] << 8))
+#define DWORD(x) (u32)((x)[0] + ((x)[1] << 8) + ((x)[2] << 16) + ((x)[3] << 24))
+#define QWORD(x) (U64(DWORD(x), DWORD(x + 4)))
+#else /* ALIGNMENT_WORKAROUND || BIGENDIAN */
 #define WORD(x) (u16)(*(const u16 *)(x))
 #define DWORD(x) (u32)(*(const u32 *)(x))
 #define QWORD(x) (*(const u64 *)(x))
-#endif /* ALIGNMENT_WORKAROUND */
+#endif /* ALIGNMENT_WORKAROUND || BIGENDIAN */
 
 #endif


### PR DESCRIPTION
Hello All:
        I am solving the issue 33 WORD and DWORD problem. This problem may cause by mistake, WORD and DWORD have different byte sizes, it may cause wrong memory device capcity in some devices.  I also redefine them in types.h file, because after SMBIOS-2.8.0,  the structure of data assume to be little-endian order. I tested DWORD and WORD in unit-tests/private/files, the DWORD result is correct and same as dmidecode result.  @licliu please help to test this patches, thanks.
