### PR TITLE
fix error support clang

### DIFF
--- a/src/dmidecodemodule.c
+++ b/src/dmidecodemodule.c
@@ -479,7 +479,8 @@ xmlNode *__dmidecode_xml_getsection(options *opt, const char *section) {
                 if(opt->type == -1) {
                         char *err = log_retrieve(opt->logdata, LOG_ERR);
                         log_clear_partial(opt->logdata, LOG_ERR, 0);
-                        _pyReturnError(PyExc_RuntimeError, "Invalid type id '%s' -- %s", typeid, err);
+                        int typeid_int = atoi(typeid); 
+                        _pyReturnError(PyExc_RuntimeError, "Invalid type id '%d' -- %s", typeid_int, err);
                         free(err);
                         return NULL;
                 }
@@ -913,8 +914,7 @@ static PyMethodDef DMIDataMethods[] = {
         {(char *)"pythonmap", dmidecode_set_pythonxmlmap, METH_O,
          (char *) "Use another python dict map definition. The default file is " PYTHON_XML_MAP},
 
-        {(char *)"xmlapi", dmidecode_xmlapi, METH_VARARGS | METH_KEYWORDS,
-         (char *) "Internal API for retrieving data as raw XML data"},
+        {"xmlapi", (PyCFunction)dmidecode_xmlapi, METH_VARARGS | METH_KEYWORDS, "Internal API for retrieving data as raw XML data"},
 
 
         {(char *)"get_warnings", dmidecode_get_warnings, METH_NOARGS,


### PR DESCRIPTION
I meet problems like this when I use clang:
[   75s] src/dmidecodemodule.c:916:28: error: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyObject *(PyObject *, PyObject *, PyObject *)' (aka 'struct _object *(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
[   75s]   916 |         {(char *)"xmlapi", dmidecode_xmlapi, METH_VARARGS | METH_KEYWORDS,
[   75s]       |                            ^~~~~~~~~~~~~~~~
[   75s] src/dmidecodemodule.c:997:9: warning: 'xmlXPathInit' is deprecated [-Wdeprecated-declarations]
[   75s]   997 |         xmlXPathInit();
[   75s]       |         ^
[   75s] /usr/include/libxml2/libxml/xpath.h:562:1: note: 'xmlXPathInit' has been explicitly marked deprecated here
[   75s]   562 | XML_DEPRECATED
[   75s]       | ^
[   75s] /usr/include/libxml2/libxml/xmlversion.h:447:43: note: expanded from macro 'XML_DEPRECATED'
[   75s]   447 | #    define XML_DEPRECATED __attribute__((deprecated))
[   75s]       |                                           ^
[   75s] src/dmidecodemodule.c:1027:72: error: incompatible function pointer types passing 'void (void *)' to parameter of type 'PyCapsule_Destructor' (aka 'void (*)(struct _object *)') [-Wincompatible-function-pointer-types]
[   75s]  1027 |         PyModule_AddObject(module, "options", PyCapsule_New(opt, NULL, destruct_options));
[   75s]       |                                                                        ^~~~~~~~~~~~~~~~
[   75s] /usr/include/python3.11/pycapsule.h:31:26: note: passing argument to parameter 'destructor' here
[   75s]    31 |     PyCapsule_Destructor destructor);
[   75s]       |                          ^
[   75s] 5 warnings and 2 errors generated.
so i did some change